### PR TITLE
Add option to disable sending TTS events to client

### DIFF
--- a/Content.Client/_Sunrise/TTS/TTSSystem.cs
+++ b/Content.Client/_Sunrise/TTS/TTSSystem.cs
@@ -43,6 +43,7 @@ public sealed class TTSSystem : EntitySystem
         _cfg.OnValueChanged(SunriseCCVars.TTSVolume, OnTtsVolumeChanged, true);
         _cfg.OnValueChanged(SunriseCCVars.TTSRadioVolume, OnTtsRadioVolumeChanged, true);
         _cfg.OnValueChanged(SunriseCCVars.TTSAnnounceVolume, OnTtsAnnounceVolumeChanged, true);
+        _cfg.OnValueChanged(SunriseCCVars.TTSClientEnabled, OnTtsClientOptionChanged, true);
         SubscribeNetworkEvent<PlayTTSEvent>(OnPlayTTS);
         SubscribeNetworkEvent<AnnounceTtsEvent>(OnAnnounceTTSPlay);
     }
@@ -53,6 +54,7 @@ public sealed class TTSSystem : EntitySystem
         _cfg.UnsubValueChanged(SunriseCCVars.TTSVolume, OnTtsVolumeChanged);
         _cfg.UnsubValueChanged(SunriseCCVars.TTSRadioVolume, OnTtsRadioVolumeChanged);
         _cfg.UnsubValueChanged(SunriseCCVars.TTSAnnounceVolume, OnTtsAnnounceVolumeChanged);
+        _cfg.UnsubValueChanged(SunriseCCVars.TTSClientEnabled, OnTtsClientOptionChanged);
         _contentRoot.Dispose();
     }
 
@@ -69,6 +71,11 @@ public sealed class TTSSystem : EntitySystem
     private void OnTtsAnnounceVolumeChanged(float volume)
     {
         _volumeAnnounce = volume;
+    }
+
+    private void OnTtsClientOptionChanged(bool option)
+    {
+        RaiseNetworkEvent(new ClientOptionTTSEvent(option));
     }
 
     private void OnAnnounceTTSPlay(AnnounceTtsEvent ev)

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
@@ -34,6 +34,13 @@ public sealed class SunriseCCVars
         CVarDef.Create("tts.api_timeout", 5, CVar.SERVERONLY | CVar.ARCHIVE);
 
     /// <summary>
+    /// Option to disable TTS events for client
+    /// </summary>
+    public static readonly CVarDef<bool> TTSClientEnabled =
+        CVarDef.Create("tts.client_enabled", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+
+    /// <summary>
     /// Default volume setting of TTS sound
     /// </summary>
     public static readonly CVarDef<float> TTSVolume =

--- a/Content.Shared/_Sunrise/TTS/ClientOptionTTSEvent.cs
+++ b/Content.Shared/_Sunrise/TTS/ClientOptionTTSEvent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Sunrise.TTS;
+
+[Serializable, NetSerializable]
+public sealed class ClientOptionTTSEvent : EntityEventArgs
+{
+    public bool Enabled { get; }
+    public ClientOptionTTSEvent(bool enabled)
+    {
+        Enabled = enabled;
+    }
+}


### PR DESCRIPTION
На некоторых сетях ТТС не помещается в пропускную способность и вызывает тротлинг. Этот PR позволяет клиенту "отписаться" от ТТСа со стороны сервера.

Обычное игнорирование пакетов со стороны клиента ни к чему не приводит, ибо они всё равно нагружают сеть.