### PR TITLE
Убрать ограничения для верхней одежды.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -8,6 +8,7 @@
     - outerClothing
   - type: Sprite
     state: icon
+  - type: AllowSuitStorage
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, что-бы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках являеться коментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изминить с помощью своего PR? --> Возвращает возможность cновва носить баллоны и оружие для всей верхней одежды.

## По какой причине
<!-- В чём причина добавления этих изменений? ССылки на Дисскусии а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!-- 
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
--> 


## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.

**Changelog**
:cl: Babaev
- tweak: Снова можно носить баллоны и оружие на всей верхней одежде
