### PR TITLE
Мелкие правки меню

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -108,7 +108,7 @@
                         <!-- <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger" VAlign="Center"
                                Text="{Loc 'ui-lobby-title'}" /> -->
                         <Label Name="ServerName" Access="Public" StyleClasses="LabelHeadingBigger" VAlign="Center"
-                               HorizontalExpand="True" HorizontalAlignment="Center" Text="Добро пожаловать в ЫЫ14" />
+                               HorizontalExpand="True" HorizontalAlignment="Center" Text="Добро пожаловать на Sunrise" />
                         <!-- Sunrise-end -->
                     </BoxContainer>
                     <!-- Gold line -->

--- a/Resources/Locale/ru-RU/preferences/loadout-groups.ftl
+++ b/Resources/Locale/ru-RU/preferences/loadout-groups.ftl
@@ -1,6 +1,8 @@
 # Miscellaneous
 loadout-group-trinkets = Безделушки
 loadout-group-glasses = Очки
+loadout-group-backpack = Рюкзак
+
 # Command
 loadout-group-captain-head = Капитан, голова
 loadout-group-captain-jumpsuit = Капитан, комбинезон

--- a/Resources/Locale/ru-RU/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/ru-RU/preferences/ui/humanoid-profile-editor.ftl
@@ -31,16 +31,18 @@ humanoid-profile-editor-preference-backpack = Рюкзак
 humanoid-profile-editor-preference-satchel = Сумка
 humanoid-profile-editor-preference-duffelbag = Вещмешок
 humanoid-profile-editor-guidebook-button-tooltip = Кликните для получения дополнительной информации
+
 # Spawn priority
 humanoid-profile-editor-preference-spawn-priority-none = Нет
 humanoid-profile-editor-preference-spawn-priority-arrivals = Зал прибытия
 humanoid-profile-editor-preference-spawn-priority-cryosleep = Капсула криосна
+
 humanoid-profile-editor-jobs-amount-in-department-tooltip = { $departmentName }
 humanoid-profile-editor-department-jobs-label = { $departmentName }
 humanoid-profile-editor-antags-tab = Антагонисты
 humanoid-profile-editor-antag-preference-yes-button = Да
 humanoid-profile-editor-antag-preference-no-button = Нет
-humanoid-profile-editor-traits-tab = Черты персонажа
+
 humanoid-profile-editor-job-priority-high-button = Высокий
 humanoid-profile-editor-job-priority-medium-button = Средний
 humanoid-profile-editor-job-priority-low-button = Низкий
@@ -48,3 +50,12 @@ humanoid-profile-editor-job-priority-never-button = Никогда
 humanoid-profile-editor-naming-rules-warning = Внимание: Оскорбительные или странные имена и описания могут повлечь за собой беседу с администрацией. Прочитайте \[Правила\].
 humanoid-profile-editor-markings-tab = Черты внешности
 humanoid-profile-editor-flavortext-tab = Описание
+
+# Traits
+humanoid-profile-editor-traits-tab = Черты персонажа
+humanoid-profile-editor-no-traits = Нет доступных черт
+
+humanoid-profile-editor-trait-count-hint = Доступно очков: [{$current}/{$max}]
+
+trait-category-disabilities = Особенности
+trait-category-speech = Особенности речи


### PR DESCRIPTION
## Кратное описание

Данный PR вносит мелкие правки в меню, такие как "Добро пожаловать на Sunrise", перевод категории рюкзаков в снаряжении, перевод вкладки "Черты персонажа"

## По какой причине

It's a bug, отсутсвие перевода категории, а так-же вкладки являеться багом, а надпись в правом верхнем углу будет напоминать игрокам где они находяться(хотя есть хаб, но надпись ЫЫ14 немного бесит)

## Медиа(Видео/Скриншоты)

![image](https://github.com/space-sunrise/space-station-14/assets/72972221/2d41a1aa-cc7f-4aa9-b4d5-1e2dac6ccf8b)
![image](https://github.com/space-sunrise/space-station-14/assets/72972221/404094d6-8e1d-4075-9cba-cdea1d6ac708)
![image](https://github.com/space-sunrise/space-station-14/assets/72972221/e25f6267-f8ee-42cc-b453-9868c0425079)


## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Rinary
- fix: Исправлена надпись в главном меню
- tweak: Переведена вкладка "Черты персонажа"
- tweak: Переведена категория "Рюкзаки" в Снаряжении
