### PR TITLE
Агост может видеть должность и мш

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -85,6 +85,8 @@
   - type: SolutionScanner
   - type: IgnoreUIRange
   - type: ShowAntagIcons
+  - type: ShowJobIcons
+  - type: ShowMindShieldIcons
   - type: Inventory
     templateId: aghost
   - type: InventorySlots


### PR DESCRIPTION
## Кратное описание
Агост теперь может видеть должность и мш игроков

## По какой причине
Удобство работы для модерации

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики