### PR TITLE
Deleted Cluster from map pool and set minPlayers 0 for all other maps

### DIFF
--- a/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
@@ -3,6 +3,5 @@
   maps:
   - SunriseDelta
   - SunriseBox
-  - SunriseCluster
   - SunriseFland
   - SunriseMarathon

--- a/Resources/Prototypes/_Sunrise/Maps/box.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/box.yml
@@ -2,7 +2,7 @@
   id: SunriseBox
   mapName: 'Box Station'
   mapPath: /Maps/_Sunrise/Station/box.yml
-  minPlayers: 30
+  minPlayers: 0
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Sunrise/Maps/delta.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/delta.yml
@@ -2,7 +2,7 @@
   id: SunriseDelta
   mapName: 'Delta Station'
   mapPath: /Maps/_Sunrise/Station/delta.yml
-  minPlayers: 40
+  minPlayers: 0
   stations:
     Delta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Sunrise/Maps/fland.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/fland.yml
@@ -2,7 +2,7 @@
   id: SunriseFland
   mapName: 'Fland Installation'
   mapPath: /Maps/_Sunrise/Station/fland.yml
-  minPlayers: 40
+  minPlayers: 0
   stations:
     Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_Sunrise/Maps/marathon.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/marathon.yml
@@ -2,7 +2,7 @@
   id: SunriseMarathon
   mapName: 'Marathon Station'
   mapPath: /Maps/_Sunrise/Station/marathon.yml
-  minPlayers: 20
+  minPlayers: 0
   stations:
     Marathon:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
Я не могу терпеть Cluster, уж простите. Там слишком мало места для антагонистов и нередко после ребута серверов он ставится и 100 человек приходится утится там.

:cl: SplikZerys
- remove: Удалена станция Cluster из пула карт.
- tweak: Минимальное количество игроков для старта карт было убрано.
-->
