### PR TITLE
Снятие биокода

### DIFF
--- a/Resources/Locale/ru-RU/_sunrise/biocode/biocode.ftl
+++ b/Resources/Locale/ru-RU/_sunrise/biocode/biocode.ftl
@@ -30,3 +30,6 @@ ent-ClothingOuterHardsuitSyndieCommanderBiocode = { ent-ClothingOuterHardsuitSyn
     .desc = { ent-ClothingOuterHardsuitSyndieCommander.desc }
 ent-ClothingOuterHardsuitJuggernautBiocode = { ent-ClothingOuterHardsuitJuggernaut }
     .desc = { ent-ClothingOuterHardsuitJuggernaut.desc }
+ent-WeaponAntiqueLaserBiocode = { ent-WeaponAntiqueLaser }
+    .desc = { ent-WeaponAntiqueLaser }
+    .suffix = Пистолет, BIOCODE

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -46,7 +46,7 @@
       - id: ClothingBeltSheathFilled
       - id: DoorRemoteCommand
       - id: RubberStampCaptain
-      - id: WeaponAntiqueLaser
+      - id: WeaponAntiqueLaserBiocode  # Sunrise-edit
       - id: JetpackCaptainFilled
       - id: MedalCase
 
@@ -72,7 +72,7 @@
       - id: ClothingBeltSheathFilled
       - id: DoorRemoteCommand
       - id: RubberStampCaptain
-      - id: WeaponAntiqueLaser
+      - id: WeaponAntiqueLaserBiocode  # Sunrise-edit
       - id: JetpackCaptainFilled
       - id: MedalCase
       - id: ClothingHeadCaptainHat

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -509,6 +509,11 @@
     - MonkeyWearable
     - Hardsuit
     - WhitelistChameleon
+  # Sunrise-start
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieBiocode
+    node: start
+  # Sunrise-end
 
 # Syndicate Medic Hardsuit
 - type: entity
@@ -527,6 +532,11 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
+  # Sunrise-start
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieMedicBiocode
+    node: start
+  # Sunrise-end
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -565,6 +575,11 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
+  # Sunrise-start
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieEliteBiocode
+    node: start
+  # Sunrise-end
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -597,6 +612,11 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
+  # Sunrise-start
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieCommanderBiocode
+    node: start
+  # Sunrise-end
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
@@ -629,6 +649,11 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
+  # Sunrise-start
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieJuggernautBiocode
+    node: start
+  # Sunrise-end
 
 #Wizard Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -80,6 +80,11 @@
     enabled: false
   - type: IgnitionSource
     temperature: 700
+  # Sunrise-start
+  - type: Construction
+    graph: EnergySwordBiocode
+    node: start
+  # Sunrise-end
 
 - type: entity
   name: pen
@@ -282,3 +287,8 @@
       right:
       - state: inhand-right-blade
         shader: unshaded
+  # Sunrise-start
+  - type: Construction
+    graph: EnergySwordDoubleNoBiocode
+    node: start
+  # Sunrise-end

--- a/Resources/Prototypes/Entities/Structures/Storage/glass_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/glass_box.yml
@@ -137,7 +137,7 @@
   - type: ContainerFill
     containers:
       ItemCabinet:
-      - WeaponAntiqueLaser
+      - WeaponAntiqueLaserBiocode  # Sunrise-edit
 
 - type: entity
   parent: [GlassBoxLaserFilled, GlassBoxLaserOpen]

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -85,7 +85,7 @@
     state: icon
 
 - type: stealTargetGroup
-  id: WeaponAntiqueLaser
+  id: WeaponAntiqueLaserBiocode  # Sunrise-edit
   name: antique laser pistol
   sprite:
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -277,7 +277,7 @@
   id: CaptainGunStealObjective
   components:
   - type: StealCondition
-    stealGroup: WeaponAntiqueLaser
+    stealGroup: WeaponAntiqueLaserBiocode  # Sunrise-edit
     owner: job-name-captain
 
 - type: entity

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Clothing/Biocode/hardsuits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Clothing/Biocode/hardsuits.yml
@@ -10,6 +10,9 @@
       path: "/Audio/Effects/beep1.ogg"
       params:
         volume: 15
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieNoBiocode
+    node: start
 
 - type: entity
   parent: ClothingOuterHardsuitSyndieMedic
@@ -23,6 +26,9 @@
       path: "/Audio/Effects/beep1.ogg"
       params:
         volume: 15
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieMedicNoBiocode
+    node: start
 
 - type: entity
   parent: ClothingOuterHardsuitSyndieElite
@@ -36,6 +42,9 @@
       path: "/Audio/Effects/beep1.ogg"
       params:
         volume: 15
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieEliteNoBiocode
+    node: start
 
 - type: entity
   parent: ClothingOuterHardsuitSyndieCommander
@@ -49,6 +58,9 @@
       path: "/Audio/Effects/beep1.ogg"
       params:
         volume: 15
+  - type: Construction
+    graph: ClothingOuterHardsuitSyndieCommanderNoBiocode
+    node: start
 
 - type: entity
   parent: ClothingOuterHardsuitJuggernaut
@@ -62,3 +74,6 @@
       path: "/Audio/Effects/beep1.ogg"
       params:
         volume: 15
+  - type: Construction
+    graph: ClothingOuterHardsuitJuggernautNoBiocode
+    node: start

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -118,6 +118,10 @@
     price: 750
   - type: StealTarget
     stealGroup: WeaponEnergyGunMultiphase
+  - type: FactionWeaponBlocker
+    factions:
+    - NanoTrasen
+    alertText: Данное оружие биокодировано. Вы не можете его использовать.
 
 - type: entity
   name: miniature energy gun

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Biocode/biocode.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Biocode/biocode.yml
@@ -107,6 +107,9 @@
     factions:
     - Syndicate
     alertText: Данное оружие биокодировано. Вы не можете его использовать.
+  - type: Construction
+    graph: EnergySwordDoubleNoBiocode
+    node: start
 
 - type: entity
   parent: EnergySword
@@ -117,6 +120,9 @@
     factions:
     - Syndicate
     alertText: Данное оружие биокодировано. Вы не можете его использовать.
+  - type: Construction
+    graph: EnergySwordNoBiocode
+    node: start
 
 - type: entity
   parent: WeaponSIAR52

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Biocode/biocode.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Biocode/biocode.yml
@@ -183,3 +183,13 @@
     factions:
     - Syndicate
     alertText: Данное оружие биокодировано. Вы не можете его использовать.
+
+- type: entity
+  parent: WeaponAntiqueLaser
+  id: WeaponAntiqueLaserBiocode
+  suffix: BIOCODE
+  components:
+  - type: FactionWeaponBlocker
+    factions:
+    - NanoTrasen
+    alertText: Данное оружие биокодировано. Вы не можете его использовать.

--- a/Resources/Prototypes/_Sunrise/Recipes/Construction/Graphs/Biocode/biocode.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Construction/Graphs/Biocode/biocode.yml
@@ -1,0 +1,185 @@
+# Weapons
+
+- type: constructionGraph
+  id: EnergySwordNoBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: nobiocode
+          steps:
+            - tool: Screwing
+              doAfter: 30
+    - node: nobiocode
+      entity: EnergySword
+
+- type: constructionGraph
+  id: EnergySwordBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: biocode
+          steps:
+            - tool: Screwing
+              doAfter: 30
+    - node: biocode
+      entity: EnergySwordBiocode
+
+- type: constructionGraph
+  id: EnergySwordDoubleNoBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: nobiocode
+          steps:
+            - tool: Screwing
+              doAfter: 30
+    - node: nobiocode
+      entity: EnergySwordDouble
+
+- type: constructionGraph
+  id: EnergySwordDoubleBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: biocode
+          steps:
+            - tool: Screwing
+              doAfter: 30
+    - node: biocode
+      entity: EnergySwordDoubleBiocode
+
+# Clothing
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieNoBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: nobiocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: nobiocode
+      entity: ClothingOuterHardsuitSyndie
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: biocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: biocode
+      entity: ClothingOuterHardsuitSyndie
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieMedicNoBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: nobiocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: nobiocode
+      entity: ClothingOuterHardsuitSyndieMedic
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieMedicBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: biocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: biocode
+      entity: ClothingOuterHardsuitSyndieMedic
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieEliteNoBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: nobiocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: nobiocode
+      entity: ClothingOuterHardsuitSyndieElite
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieEliteBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: biocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: biocode
+      entity: ClothingOuterHardsuitSyndieElite
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieCommanderNoBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: nobiocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: nobiocode
+      entity: ClothingOuterHardsuitSyndieCommander
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieCommanderBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: biocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: biocode
+      entity: ClothingOuterHardsuitSyndieCommander
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieJuggernautNoBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: nobiocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: nobiocode
+      entity: ClothingOuterHardsuitSyndieJuggernaut
+
+- type: constructionGraph
+  id: ClothingOuterHardsuitSyndieJuggernautBiocode
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: biocode
+          steps:
+            - tool: Screwing
+              doAfter: 45
+    - node: biocode
+      entity: ClothingOuterHardsuitSyndieJuggernaut


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
В этом ПР я попытался дать возможность снимать биокод с некоторых вещей. Основной проблемой стала невозможность сделать подобное снятие биокода (через constructionGraph) для предметов с патронами/зарядами. Поэтому только лазерные мечи и броня. 
Также дал биокод НТ пистолету капитана и пистолету ОСЩ. Сделано это было как попытка ограничить ЯО в использовании их для своих целей. У них есть свои лазерки в аплинке, нехуй. 

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: pacable
- add: Добавлена возможность снятия биокода с некоторой экипировки
- add: Теперь у антикварного пистолета и пистолета ОСЩ есть биокод