### PR TITLE
Фикс телескопической дубинки

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/telebaton.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/telebaton.yml
@@ -15,6 +15,8 @@
         volume: -5
   - type: ItemToggleSize
     activatedSize: Normal
+    activatedShape:
+    - 0,0,0,2
   - type: ItemToggleDisarmMalus
     activatedDisarmMalus: 0.6
   - type: Sprite
@@ -37,12 +39,14 @@
         Blunt: 0
   - type: Telescopicbaton
   - type: StaminaDamageOnHit
-    damage: 10
+    damage: 20
   - type: UseDelay
     delay: 0.4
   - type: Item
     sprite: _Sunrise/Objects/Weapons/Melee/telebaton.rsi
     size: Small
+    shape:
+    - 0,0,0,0
   - type: Appearance
   - type: ToggleableLightVisuals
     spriteLayer: blade


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

- В не активном состоянии - 1 плитка
- В активном - 3 плитки
- Дамаг стамины увеличен до 20(5 ударов по голому человеку)

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

Удар по стамине увеличен из-за нерфа тупых ударов, бафф размеров так как дубинка должна быть меньше чем лом

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

![image](https://github.com/space-sunrise/space-station-14/assets/72972221/7c56bffb-99f6-4c1b-b5dc-70db26afd07d)
![image](https://github.com/space-sunrise/space-station-14/assets/72972221/189b318e-1a68-43c3-ac20-cc1bea9c9c6a)


## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Rinary
 - tweak: Урон Телескопической дубинки по стамине увеличен с 10 до 20(5 ударов)
 - tweak: Размер активной дубинки изменен с 2 на 2 до 1 на 3
 - tweak: Размер не активной дубинки изменен с 1 на 2 до 1 на 1