### PR TITLE
Блеклист расс ядерных оперативников

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -87,6 +87,20 @@
     #Once the issues are fixed the species should be removed from this list to be enabled.
     #Balance concerns are not a valid reason to disable a species, except for high-impact Nukie-specific exploits.
     - Vox
+    #Sunrise edit start
+    - SlimePerson
+    - Skeleton
+    - Reptilian
+    - Moth
+    - Gingerbread
+    - Diona
+    - Arachnid
+    - Felinid
+    - HumanoidXeno
+    - Predator
+    - Swine
+    - Vulpkanin
+    #End
 
 - type: entity
   parent: BaseNukeopsRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -90,15 +90,10 @@
     #Sunrise edit start
     - SlimePerson
     - Skeleton
-    - Reptilian
-    - Moth
     - Gingerbread
     - Diona
-    - Arachnid
     - Felinid
-    - HumanoidXeno
     - Predator
-    - Swine
     - Vulpkanin
     #End
 


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Теперь ядерные оперативники как и положенно имеют блеклист расс, пока-что на сервере запрещены только воксы, этот же PR предлагает добавить некоторые рассы в блеклист:

- SlimePerson
- Skeleton
- Gingerbread
- Diona
- Felinid
- Predator
- Vulpkanin

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

Я считаю это правильным решением, так как сомневаюсь что синдикековцы будут посылать на важные задания вульп, феленидов или свиней.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

Не содержит внутриигровых изменений, лишь настройка

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->

:cl: Rinary
 - tweak: Изменен блеклист ядерных оперативников, теперь в него входят все рассы кроме людей и дворфов
