### PR TITLE
Перевод поглаживания вульп

### DIFF
--- a/Resources/Locale/ru-RU/_sunrise/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/ru-RU/_sunrise/interaction/interaction-popup-component.ftl
@@ -1,2 +1,3 @@
 petting-success-gorilla = Вы гладите { $target } по { POSS-ADJ($target) } массивной голове.
 petting-failure-gorilla = Вы тянетесь погладить { $target }, но { $target } встаёт в полный рост, затрудняя такую возможность.
+pat-success-generic = Вы гладите { $target } по { POSS-ADJ($target) } голове.


### PR DESCRIPTION
## Кратное описание
Сейчас, если гладить вульп с помощью ЛКМ - пишет pat-success-generic, так как нет перевода. Одна строчка.

## По какой причине
Выглядит странно и криво, перевод требовался в обязательном порядке.

## Медиа(Видео/Скриншоты)
![изображение](https://github.com/user-attachments/assets/8aee69f5-cf40-4418-983e-8162fe0d8fd3)

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**


:cl: SShved
- add: Добавлен перевод поглаживаниям вульпканинов.
