### PR TITLE
Уменьшение количества генокрадов

### DIFF
--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -41,8 +41,8 @@
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      max: 5
-      playerRatio: 10
+      max: 3
+      playerRatio: 15
       lateJoinAdditional: true
       mindComponents:
       - type: ChangelingRole


### PR DESCRIPTION
1 генокрад убивает 15 человек. Если приходится по 1 генокраду на 10 человек, то серверу наступает полноценная пизда. 

# Не беспокойся о донатах, меня донатеры молят уменьшить количество генокрадов


:cl: pacable
- tweak: Максимальное количество генокрадов в раунде уменьшено до 3.