### PR TITLE
Ребаланс феленидов

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/felinid.yml
@@ -20,7 +20,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.20
-        density: 150
+        density: 165
         restitution: 0.0
         mask:
         - MobMask
@@ -34,8 +34,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      50: Critical
-      100: Dead
+      75: Critical
+      150: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       30: 0.7
@@ -94,6 +94,10 @@
   - type: MovementSpeedModifier
     baseSprintSpeed: 4.0
     baseWalkSpeed: 2.0
+  - type: DamagedByFlashing
+    flashDamage:
+      types:
+        Shock: 5.0
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Перебаланс феленидов. Повышено хп, density, в замен добавлен урон от вспышки.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

Такая-же история как с осщ, игроки считают что фелениды самая отвратительная расса по балансу.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Rinary
 - tweak: Пересмотрено хп у феленидов(0 - Alive, 75 - Crit, 150 - Dead)
 - tweak: Пересмотрено density у феленидов(150 было, 165 стало)
 - add: Из-за чуствительных глазок, фелениды получают 5 урона за каждое ослепление.(Ослепляйте феленидов насмерть, всего-то 15 зарядов вспышки)