### PR TITLE
Понизил порог выключения вентиляций от давления

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -57,7 +57,7 @@
             Welded: { state: vent_welded }
             Lockout: { state: vent_lockout }
     - type: GasVentPump
-      underPressureLockoutThreshold: 10 # Sunrise-Edit
+      underPressureLockoutThreshold: 0 # Sunrise-Edit
     - type: Construction
       graph: GasUnary
       node: ventpump

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -57,7 +57,7 @@
             Welded: { state: vent_welded }
             Lockout: { state: vent_lockout }
     - type: GasVentPump
-      underPressureLockoutThreshold: 10
+      underPressureLockoutThreshold: 10 # Sunrise-Edit
     - type: Construction
       graph: GasUnary
       node: ventpump

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -57,6 +57,7 @@
             Welded: { state: vent_welded }
             Lockout: { state: vent_lockout }
     - type: GasVentPump
+      underPressureLockoutThreshold: 10
     - type: Construction
       graph: GasUnary
       node: ventpump


### PR DESCRIPTION
## Кратное описание
Понизил порог выключения вентиляций из-за давления [80 кПа > 10 кПа].

## По какой причине
- В связи с тем что у нас на станциях стоят газодобытчики - мы не подвергаемся рискам растраты всего запаса воздуха на станции. Учитывая это нам не требуется отключать Вентиляции при малейшей разгерметизации.
- Так же учитывая то что у нас Атмосы не умеют чинить разгермы - лучше чтоб вентиляции работали по долгу, и наполняли станцию воздухом. В противном случае экипаж будет гибнуть от нехватки воздуха.

## Медиа(Видео/Скриншоты)
![image](https://github.com/user-attachments/assets/c5fb81ef-c8b2-4632-9897-da62b1f981d4)


## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики.

**Changelog**
:cl: Parashut
- tweak: Понизил порог выключения вентиляций от давления [80 кПа > 10 кПа].
