### PR TITLE
Train в map pool

### DIFF
--- a/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
@@ -7,6 +7,6 @@
   - SunriseMarathon
   - SunriseBagel
 #  - SunriseReach
-#  - SunriseTrain
+  - SunriseTrain
   - SunriseMeta
 # НЕ ДОБАВЛЯТЬ НОВЫЕ КАРТЫ БЕЗ МОЕГО РЕВЬЮ! ~ SplikZerys


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Вернул SunriseTrain в MapPool
 
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

Я считаю что нужно вернуть Train в Map Pool, потому-что его уже исправили(а удаляли потому-что был неисправен) и это одна из тех карт которые уникальны среди других.

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Rinary
- tweak: Был возвращен Train в Map Pool