### PR TITLE
Очки адъютанта и наборы мехов для ядеров

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -46,6 +46,7 @@
       - id: DoubleEmergencyNitrogenTankFilled
       - id: ToolboxSyndicateFilled
       - id: PlushieNuke
+      - id: WelderIndustrial # Удалить когда ремонт мехов будет дешевле по сварочному топливу
 
 - type: entity
   id: CrateCybersunRoverBundle
@@ -62,6 +63,7 @@
       - id: DoubleEmergencyNitrogenTankFilled
       - id: ToolboxSyndicateFilled
       - id: PlushieNuke
+      - id: WelderIndustrial # Удалить когда ремонт мехов будет дешевле по сварочному топливу
 
 - type: entity
   id: CrateCybersunMaulerBundle
@@ -78,3 +80,4 @@
       - id: DoubleEmergencyNitrogenTankFilled
       - id: ToolboxSyndicateFilled
       - id: PlushieNuke
+      - id: WelderIndustrial # Удалить когда ремонт мехов будет дешевле по сварочному топливу

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -41,11 +41,12 @@
   - type: StorageFill
     contents:
       - id: MechGygaxSyndieFilled
+      - id: HandheldMechAnalyzer
       - id: DoubleEmergencyOxygenTankFilled
       - id: DoubleEmergencyNitrogenTankFilled
       - id: ToolboxSyndicateFilled
       - id: PlushieNuke
-      
+
 - type: entity
   id: CrateCybersunRoverBundle
   suffix: Filled
@@ -56,6 +57,7 @@
   - type: StorageFill
     contents:
       - id: MechRoverSyndieFilled
+      - id: HandheldMechAnalyzer
       - id: DoubleEmergencyOxygenTankFilled
       - id: DoubleEmergencyNitrogenTankFilled
       - id: ToolboxSyndicateFilled
@@ -71,6 +73,7 @@
   - type: StorageFill
     contents:
       - id: MechMaulerSyndieFilled
+      - id: HandheldMechAnalyzer
       - id: DoubleEmergencyOxygenTankFilled
       - id: DoubleEmergencyNitrogenTankFilled
       - id: ToolboxSyndicateFilled

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Adjutant/adjutant.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Adjutant/adjutant.yml
@@ -41,7 +41,7 @@
   id: AdjutantGear
   equipment:
     shoes: ClothingShoesBootsLaceup
-    eyes: ClothingEyesHudCommand
+    eyes: ClothingEyesGlassesSunglasses
     id: AdjutantPDA
     ears: ClothingHeadsetAdjutant
     neck: ClothingNeckMantleAdjutant

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Adjutant/adjutant.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Adjutant/adjutant.yml
@@ -41,7 +41,7 @@
   id: AdjutantGear
   equipment:
     shoes: ClothingShoesBootsLaceup
-    eyes: ClothingEyesGlassesCommand
+    eyes: ClothingEyesHudCommand
     id: AdjutantPDA
     ears: ClothingHeadsetAdjutant
     neck: ClothingNeckMantleAdjutant


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
В наборы мехов добавлен анализатор мехов, также добавлен промышленный сварочный апарат
Административные очки адъютанта заменены на административный визор

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Ядерным оперативникам нужен анализатор чтобы понимать текущее состояние мехов, сварка нужна чтобы упростить ремонт мехов
Административный визор задумывался как упрощение работы гп, а очки как повышение выживаемости капитана. Не имеет смысла давать ни то, ни то адъютанту

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
Без скриншотов

## Проверки

- [X] Я не требую помощи для завершения PR
- [X] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [X] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.
-->
:cl: J C Denton
- tweak: Наборы мехов ядерных оперативников теперь идут с анализатором мехов.
- tweak: Административные очки у адъютанта заменены на солнцезащитные.