### PR TITLE
Нерф дракона

### DIFF
--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     /// <summary>
     /// The maximum amount we can accumulate before becoming impervious.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("maxAccumuluator")] public float MaxAccumulator = 200f;
+    [ViewVariables(VVAccess.ReadWrite), DataField("maxAccumuluator")] public float MaxAccumulator = 300f;
 
     /// <summary>
     /// Accumulation of the spawn timer.
@@ -33,7 +33,7 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     /// How long it takes for a new spawn to be added.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("spawnCooldown")]
-    public float SpawnCooldown = 20f;
+    public float SpawnCooldown = 30f;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("spawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string SpawnPrototype = "MobCarpDragon";

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -133,8 +133,8 @@
       path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
     damage:
       types:
-        Piercing: 25 #Sunrise-edit
-        Slash: 25 #Sunrise-edit
+        Piercing: 15
+        Slash: 15
   - type: Devourer
     foodPreference: Humanoid
     shouldStoreDevoured: true
@@ -165,6 +165,8 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Dragon
+  - type: TTS
+    voice: HearthstoneLordOfThunder
   # Sunrise-End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
@@ -10,8 +10,20 @@
     anchored: true
   - type: Physics
     bodyType: Static
-    canCollide: false
+    canCollide: true #Sunrise-edit
   - type: Fixtures
+#Sunrise-start
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.48,0.25,0.48"
+        density: 75
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+#Sunrise-end
   - type: Sprite
     layers:
     - sprite: Structures/Specific/carp_rift.rsi
@@ -32,8 +44,8 @@
     # only show after making the announcement at 50%
     enabled: false
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageContainer: Rift #Sunrise-edit
+    damageModifierSet: Rift #Sunrise-edit
   - type: Destructible
     thresholds:
     - trigger:
@@ -46,9 +58,5 @@
     sound:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
 #Sunrise-start
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.70
-        Slash: 0.70
+  - type: DamageOverlay
 #Sunrise-end

--- a/Resources/Prototypes/_Sunrise/Damage/containers.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/containers.yml
@@ -15,3 +15,8 @@
   - Heat
   - Shock
   - Caustic
+
+- type: damageContainer
+  id: Rift
+  supportedGroups:
+  - Brute

--- a/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Sunrise/Damage/modifier_sets.yml
@@ -42,4 +42,11 @@
     Blunt: 0.8
     Slash: 0.8
     Piercing: 0.8
-    Heat: 0.3
+    Heat: 0.6
+
+- type: damageModifierSet
+  id: Rift
+  coefficients:
+    Blunt: 0.6
+    Slash: 0.6
+    Piercing: 0.6


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Нерф дракона
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Перебафал
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: kanopus7
- tweak: Дракону возвращен изначальный урон с основной атаки.
- tweak: Возвращен кулдаун спавна карпов.
- tweak: Возвращена прежняя скорость зарядки разлома.
- tweak: Теперь карповый разлом получает урон от прожектайлов.
- tweak: Резисты дракона к тепловому урону теперь 40%.
- add: Карповый разлом получил резисты.
- add: Дракону добавлен TTS Владыки Грома.