### PR TITLE
Fix Firelock Closed Drawdepth

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -63,6 +63,7 @@
           - AirlockLayer
     - type: Door
       openDrawDepth: WallTops
+      closedDrawDepth: BlastDoors # Sunrise-edit
       closeTimeOne: 0.1
       closeTimeTwo: 0.6
       openTimeOne: 0.1


### PR DESCRIPTION
до:
![image](https://github.com/user-attachments/assets/49a5add7-a3d3-436c-b118-c904f3651eb1)

после:
![image](https://github.com/user-attachments/assets/cb29b56f-2c10-4b6f-85a0-3927c2eeaa30)
