### PR TITLE
Обновление брифинга Дракона

### DIFF
--- a/Resources/Locale/ru-RU/_strings/dragon/dragon.ftl
+++ b/Resources/Locale/ru-RU/_strings/dragon/dragon.ftl
@@ -1,3 +1,3 @@
 dragon-round-end-agent-name = дракон
 objective-issuer-dragon = [color=#7567b6]Космический дракон[/color]
-dragon-role-briefing = Создайте 3 карповых разлома и захватите этот квадрант!
+dragon-role-briefing = Создайте 3 карповых разлома и захватите этот квадрант! Летите к станции на {$direction}.


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Сделав спавн дракона вне станции, в брифинг Дракона была добавлена строка о направлении до станции. Данный PR просто обновляет локализацию брифинга Дракона.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Чтобы челы не летали в поисках станции по 10 минут

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="1214" alt="Screenshot 2024-11-10 at 02 10 27" src="https://github.com/user-attachments/assets/4a987e90-ee9d-4771-a641-20dab900d9cd">

## Проверки

- [X] Я не требую помощи для завершения PR
- [X] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [X] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.
-->
:cl: J C Denton
- fix: Брифинг Дракона теперь сообщает направление до станции.