### PR TITLE
Удалил годмод у оружейки гамма кода.

### DIFF
--- a/Content.Server/_Sunrise/Shuttles/CodeEquipmentSystem.cs
+++ b/Content.Server/_Sunrise/Shuttles/CodeEquipmentSystem.cs
@@ -47,7 +47,6 @@ public sealed class CodeEquipmentSystem : EntitySystem
         comp.Shuttles.Add(shuttleUids[0]);
         var gammaArmoryComp = EnsureComp<CodeEquipmentShuttleComponent>(shuttleUids[0]);
         gammaArmoryComp.Station = uid;
-        EnsureComp<ImmortalGridComponent>(shuttleUids[0]);
     }
 
     private void OnFTLShuttleTag(EntityUid uid, CodeEquipmentShuttleComponent comp, ref FTLTagEvent ev)


### PR DESCRIPTION
Исправляет https://github.com/space-sunrise/space-station-14/issues/648

:cl: pacable
- fix: Больше оружейная комната гамма кода не обладает годмодом.
