### PR TITLE
Временное отключение представителя НТ

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -75,7 +75,7 @@
   - ERTEngineer
   - DeathSquad
   - CentCommOfficial
-  - NanoTrasenRepresentative  #Sunrise-Edit
+  # - NanoTrasenRepresentative  #Sunrise-Edit
   - Adjutant  #Sunrise-edit
   primary: false
   weight: 100

--- a/Resources/Prototypes/_Sunrise/Maps/bagel.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/bagel.yml
@@ -22,7 +22,7 @@
           #service
           Captain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
-          NanoTrasenRepresentative: [ 1, 1 ]
+          # NanoTrasenRepresentative: [ 1, 1 ]
           Adjutant: [ 1, 1 ]
           Bartender: [ 2, 2 ]
           Botanist: [ 3, 3 ]

--- a/Resources/Prototypes/_Sunrise/Maps/box.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/box.yml
@@ -21,7 +21,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
             Adjutant: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]

--- a/Resources/Prototypes/_Sunrise/Maps/cog.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/cog.yml
@@ -84,7 +84,7 @@
             Roboticist: [ 2, 2 ]
             # Sunrise-Command
             Adjutant: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
         - type: StationGoal
           goals:
           - Shuttle

--- a/Resources/Prototypes/_Sunrise/Maps/delta.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/delta.yml
@@ -57,7 +57,7 @@
             Psychologist: [ 1, 1 ]
             Detective: [ 1, 1 ]
             Paramedic: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
             # Sunrise-Law
             IAA: [ 1, 1 ]
             Lawyer: [ 2, 2 ]

--- a/Resources/Prototypes/_Sunrise/Maps/fland.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/fland.yml
@@ -21,7 +21,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
             Adjutant: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 4, 4 ]

--- a/Resources/Prototypes/_Sunrise/Maps/gelta.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/gelta.yml
@@ -57,7 +57,7 @@
             Psychologist: [ 1, 1 ]
             Detective: [ 1, 1 ]
             Paramedic: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
             # Sunrise-Law
             IAA: [ 1, 1 ]
             Lawyer: [ 2, 2 ]

--- a/Resources/Prototypes/_Sunrise/Maps/marathon.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/marathon.yml
@@ -21,7 +21,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
             Adjutant: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]

--- a/Resources/Prototypes/_Sunrise/Maps/meta.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/meta.yml
@@ -21,7 +21,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
             Adjutant: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]

--- a/Resources/Prototypes/_Sunrise/Maps/oasis.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/oasis.yml
@@ -82,7 +82,7 @@
             Roboticist: [ 2, 2 ]
             # Sunrise-Command
             Adjutant: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
         - type: StationGoal
           goals:
           - Shuttle

--- a/Resources/Prototypes/_Sunrise/Maps/train.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/train.yml
@@ -21,7 +21,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            NanoTrasenRepresentative: [ 1, 1 ]
+            # NanoTrasenRepresentative: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chef: [ 2, 2 ]


### PR DESCRIPTION
Представитель НТ был изуродован его СРП. Он постоянно сидит на мостике, афкшит, и при этом он отпиливает геймплей у всех отделов, при этом не добавляя ничего. Также его трость показала имбаланс.

Цитирую предложки:
> Сам Представитель Корпорации, который является каким-то зааппаным-перебафанным АВД и нередко выступает в роли "диванного эксперта". По факту он НИЧЕГО для станции жизненного не делает, что оправдывало бы наличие роли с таким огромным количеством власти и привелегий: чтобы уволить капитана у нас есть СОВЕТ ГЛАВ или можно отправить ЖБ на ЦК, разбирать нарушение глав и предоставлять им юридическую защиту на допросе - совместный долг Капитана и АВД (вернее, был до введении ПК), чтобы капитан получил по башке за свои деяние - есть Магистрат и АВД, у которых подобные ситуации в СРП прописаны.

Первоначальная задумка ПНТ хорошая, но вот по факту вышло, что ПНТ - первый клиент оружейной комнаты после объявления красного кода, ПНТ - первый, кто гонится за клоуном с дубинкой (которая причем не самая хуевая, она очень больно бьет, что замечательно и абузят игроки). 

Я предлагаю отключить ПНТ и посмотреть на влияние этого решения. Этот ПР открыт к обсуждению и я жду ваше мнение в комментариях.

:cl: pacable
- remove: Отключен представитель НТ.
