### PR TITLE
Теперь можно выбирать иконки старших ролей.

### DIFF
--- a/Resources/Prototypes/StatusIcon/job.yml
+++ b/Resources/Prototypes/StatusIcon/job.yml
@@ -411,7 +411,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorPhysician
-  allowSelection: false
+  allowSelection: true  # Sunrise-edit
 
 - type: jobIcon
   parent: JobIcon
@@ -419,7 +419,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorOfficer
-  allowSelection: false
+  allowSelection: true  # Sunrise-edit
 
 - type: jobIcon
   parent: JobIcon
@@ -427,7 +427,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorEngineer
-  allowSelection: false
+  allowSelection: true  # Sunrise-edit
 
 - type: jobIcon
   parent: JobIcon
@@ -435,7 +435,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorResearcher
-  allowSelection: false
+  allowSelection: true  # Sunrise-edit
 
 - type: jobIcon
   parent: JobIcon


### PR DESCRIPTION
Захуя это? Потому что оффы удалили старшие роли и отключили это. А у нас эти роли есть. И отключать не надо.

closes https://github.com/space-sunrise/space-station-14/issues/749

:cl: pacable
- fix: Теперь в интерфейсе айди карты агента можно выбирать иконки старших ролей.
