### PR TITLE
Remove flash damage

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/felinid.yml
@@ -94,10 +94,10 @@
   - type: MovementSpeedModifier
     baseSprintSpeed: 4.0
     baseWalkSpeed: 2.0
-  - type: DamagedByFlashing
-    flashDamage:
-      types:
-        Shock: 5.0
+#  - type: DamagedByFlashing
+#    flashDamage:
+#      types:
+#        Shock: 5.0
 #  - type: NightVision
 #    isToggle: true
 #    color: "#808080"


### PR DESCRIPTION
## По какой причине
Этот урон добавлялся как дебаф к ночному зрению, а раз ночное зрение убрали то урон от вспышек тоже следует убрать ня.

**Changelog**

🆑 Luna3

- remove: Фелинидам убран урон от вспышек.

