### PR TITLE
QOF для Боевого Борга СБ

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Player/silicon.yml
@@ -15,7 +15,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMedium
+        startingItem: PowerCellHigh
   - type: RandomMetadata
     nameSegments: [names_borg]
 


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Заменил стартовую батарейку со средней на Сб-шную. высокоемкую прирост 300 ват

## По какой причине
Каждый раунд вижу как в начале борг/борги бегут в СБ за высоко ёмкими батарейками а после в рнд.
Я думаю что Боргам обычным это пока лишнее а вот Боевой борг что не имеет никаких других выборов шасси самое то получить дополнительное отличительное свойство.

## Медиа(Видео/Скриншоты)
## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: KaiserMaus
- tweak: Борги станции теперь имеют батарейки высокой емкости.

