### PR TITLE
Нерф зажиг, Бафф простых Револьверов.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
@@ -9,7 +9,7 @@
       tags:
         - CartridgeMagnum
     proto: CartridgeMagnum
-    capacity: 12
+    capacity: 18 #Sunrise-Edit
   - type: Item
     size: Small
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletLightRifleIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.45
+    fireStacks: 0.8 # Sunrise-Edit
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletLightRifleIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.25
+    fireStacks: 0.45
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletLightRifleIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.8 # Sunrise-Edit
+    fireStacks: 0.7 # Sunrise-Edit
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletMagnumIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.45
+    fireStacks: 0.8 # Sunrise-Edit
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletMagnumIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.25
+    fireStacks: 0.45
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletPistolIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.8 # Sunrise-Edit
+    fireStacks: 0.7 # Sunrise-Edit
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletPistolIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.25
+    fireStacks: 0.45
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletPistolIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.45
+    fireStacks: 0.8 # Sunrise-Edit
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletRifleIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.45
+    fireStacks: 0.8 # Sunrise-Edit
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -49,7 +49,7 @@
   - type: HitScanCartridgeAmmo
     proto: BulletRifleIncendiary
   - type: IgniteOnAmmoHit
-    fireStacks: 0.25
+    fireStacks: 0.45
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -116,7 +116,7 @@
   - type: HitScanCartridgeAmmo
     proto: PelletShotgunIncendiarySpread
   - type: IgniteOnAmmoHit
-    fireStacks: 0.25
+    fireStacks: 0.45
   - type: SpentAmmoVisuals
     state: "incendiary"
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -116,7 +116,7 @@
   - type: HitScanCartridgeAmmo
     proto: PelletShotgunIncendiarySpread
   - type: IgniteOnAmmoHit
-    fireStacks: 0.8 # Sunrise-Edit
+    fireStacks: 0.6 # Sunrise-Edit
   - type: SpentAmmoVisuals
     state: "incendiary"
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -116,7 +116,7 @@
   - type: HitScanCartridgeAmmo
     proto: PelletShotgunIncendiarySpread
   - type: IgniteOnAmmoHit
-    fireStacks: 0.45
+    fireStacks: 0.8 # Sunrise-Edit
   - type: SpentAmmoVisuals
     state: "incendiary"
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -18,4 +18,4 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 5
+        Piercing: 12 #Sunrise-Edit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -29,8 +29,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 16
+        Blunt: 6 #Sunrise-Start
+        Piercing: 10
+        Heat: 3 #Sunrise-End
 
 - type: entity
   id: BulletLightRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -29,8 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 6 #Sunrise-Start
-        Piercing: 10
+        Blunt: 13 #Sunrise-Start
         Heat: 3 #Sunrise-End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -29,8 +29,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 32
+        Blunt: 15 #Sunrise-Start
+        Piercing: 15
+        Heat: 5 #Sunrise-End
 
 - type: entity
   id: BulletMagnumAP

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -29,8 +29,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 15 #Sunrise-Start
-        Piercing: 15
+        Blunt: 10 #Sunrise-Start
+        Piercing: 10
         Heat: 5 #Sunrise-End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -29,8 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 4 #Sunrise-Start
-        Piercing: 10
+        Blunt: 8 #Sunrise-Start
         Heat: 2 #Sunrise-End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -29,8 +29,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
-        Heat: 14
+        Blunt: 4 #Sunrise-Start
+        Piercing: 10
+        Heat: 2 #Sunrise-End
 
 - type: entity
   id: BulletPistolUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -29,8 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 7 #Sunrise-Start
-        Piercing: 10
+        Blunt: 12 #Sunrise-Start
         Heat: 2 #Sunrise-End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -29,8 +29,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
-        Heat: 15
+        Blunt: 7 #Sunrise-Start
+        Piercing: 10
+        Heat: 2 #Sunrise-End
 
 - type: entity
   id: BulletRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -12,6 +12,8 @@
     damage:
       types:
         Piercing: 28
+        Blunt: 10
+        Structural: 10
 
 - type: entity
   id: PelletShotgunBeanbag
@@ -68,8 +70,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 7
+        Blunt: 4 #Sunrise-Start
+        Piercing: 3
+        Heat: 3 #Sunrise-End
   - type: IgnitionSource
     ignited: true
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -70,8 +70,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 4 #Sunrise-Start
-        Piercing: 3
+        Blunt: 5 #Sunrise-Start
         Heat: 3 #Sunrise-End
   - type: IgnitionSource
     ignited: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -65,7 +65,7 @@
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: Gun
-    fireRate: 2
+    fireRate: 2.2 #Sunrise-Edit
   - type: RevolverAmmoProvider
     capacity: 5
     chambers: [ True, True, True, True, True ]
@@ -88,6 +88,9 @@
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
   - type: Clothing
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
+  - type: Gun #Sunrise-Start
+    selectedMode: SemiAuto
+    fireRate: 2 #Sunrise-End
   - type: RevolverAmmoProvider
     capacity: 6
     chambers: [ True, True, True, True, True, True ]
@@ -120,7 +123,7 @@
     sprite: Objects/Weapons/Guns/Revolvers/python.rsi
   - type: Gun
     selectedMode: SemiAuto
-    fireRate: 2
+    fireRate: 2.6 #Sunrise-Edit
     availableModes:
     - SemiAuto
     soundGunshot:
@@ -152,7 +155,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
   - type: Gun
-    fireRate: 1
+    fireRate: 1.7 #Sunrise-Edit
   - type: ContainerContainer
     containers:
       revolver-ammo: !type:Container

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -60,7 +60,6 @@
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
-    - Burst
     - FullAuto
     soundGunshot:
       path: /Audio/_Sunrise/Weapons/Guns/Pistols/vp70_shot.ogg
@@ -109,7 +108,6 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-    - Burst
     - FullAuto
     soundGunshot:
       collection: glock22
@@ -184,7 +182,6 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-    - Burst
     - FullAuto
     soundGunshot:
       path: /Audio/_Sunrise/Weapons/Guns/Pistols/vp70_shot.ogg
@@ -231,7 +228,6 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-    - Burst
     - FullAuto
     soundGunshot:
       collection: glock22
@@ -290,10 +286,13 @@
   - type: Item
     sprite: _Sunrise/Objects/Weapons/Guns/Pistols/deagle/tiny.rsi
   - type: Gun
-    selectedMode: SemiAuto
+    minAngle: 1
+    maxAngle: 20
+    angleIncrease: 8
+    angleDecay: 9
+    fireRate: 4.5
     availableModes:
     - SemiAuto
-    - FullAuto
     soundGunshot:
       collection: deagle
       params:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -54,8 +54,9 @@
   id: BulletPistolIncendiary
   damage:
     types:
-      Blunt: 2
-      Heat: 14
+      Blunt: 6
+      Piercing: 4
+      Heat: 2
   collisionMask: BulletImpassable
   reflective: NonEnergy
   bulletTracer:
@@ -112,8 +113,9 @@
   id: BulletRifleIncendiary
   damage:
     types:
-      Blunt: 2
-      Heat: 15
+      Blunt: 8
+      Piercing: 4
+      Heat: 3
   collisionMask: BulletImpassable
   reflective: NonEnergy
   bulletTracer:
@@ -170,8 +172,9 @@
   id: BulletMagnumIncendiary
   damage:
     types:
-      Blunt: 3
-      Heat: 32
+      Blunt: 12
+      Piercing: 10
+      Heat: 5
   collisionMask: BulletImpassable
   reflective: NonEnergy
   bulletTracer:
@@ -240,8 +243,9 @@
   id: BulletLightRifleIncendiary
   damage:
     types:
-      Blunt: 3
-      Heat: 16
+      Blunt: 8
+      Piercing: 4
+      Heat: 4
   collisionMask: BulletImpassable
   reflective: NonEnergy
   bulletTracer:
@@ -373,7 +377,9 @@
   id: PelletShotgunSlug
   damage:
     types:
-      Piercing: 28
+      Piercing: 38
+      Structural: 15
+    staminaDamage: 5
   collisionMask: BulletImpassable
   reflective: NonEnergy
   bulletTracer:
@@ -398,8 +404,8 @@
   id: PelletShotgunIncendiarySpread
   damage:
     types:
-      Blunt: 3
-      Heat: 7
+      Blunt: 5
+      Heat: 2
   collisionMask: BulletImpassable
   reflective: NonEnergy
   bulletTracer:


### PR DESCRIPTION
## Кратное описание
Бафф слабых револьверов (Детектива,пиратов, Синдиката)
На 6 патронов больше в пачках патронов для 45 магнум.
Дебафф Зажигательных: Урон меньше примерно на 20-30% но сами патроны быстрее поджигают, не привнесёт много урона если: Космос, противник имеет пожаростойкую броню, Огнетушитель.
Бафф .50 ружейных Пулевых
## По какой причине
Пистолеты револьверы устарели. детективу сейчас выгоднее взять Глок и иметь и легкость смены патронов и выше DPS
Зажиги под хитскан
Слаги очень слабоваты как для боеприпасов для дробовика, буквально нет смысла использовать дробовик на слагах когда есть дробь

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: KaiserMaus
- tweak: Зажигательные патроны стали больше поджигать цель.

