### PR TITLE
Убрал Оазис из Маппула

### DIFF
--- a/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
@@ -9,6 +9,6 @@
   - SunriseReach
   - SunriseTrain
   - SunriseMeta
-  - SunriseOasis
+  #- SunriseOasis Играбельна но требует небольшой доработки
   - SunriseCog
 # НЕ ДОБАВЛЯТЬ НОВЫЕ КАРТЫ БЕЗ МОЕГО РЕВЬЮ! ~ SplikZerys


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Убрал Оазис из Маппула

## По какой причине
Карта играбельна но требует дальнейших обновлений и доработки для повышения качества игры.
Администраторы всё ещё могут поставить её если захотят
## Медиа(Видео/Скриншоты)
None
## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: KaiserMaus
- remove: Оазис удалён из пула карт.


