### PR TITLE
Глава Персонала, КМ, НР, ГВ, СИ - Могут стать антагонистами

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -19,7 +19,7 @@
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Edit-by-RaMbUt878
   radioBold: true # Sunrise-Edit
   displayWeight: 40  # Sunrise-Edit
   access:
@@ -32,8 +32,6 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -20,7 +20,7 @@
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Edit-by-RaMbUt878
   radioBold: true # Sunrise-Edit
   displayWeight: 90 # Sunrise-Edit
   access:
@@ -52,8 +52,6 @@
   - Medical
   - Barber  # Sunrise-edit
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -21,7 +21,7 @@
   supervisors: job-supervisors-captain
   radioBold: true # Sunrise-Edit
   displayWeight: 70 # Sunrise-Edit
-  canBeAntag: false
+  canBeAntag: true # RaMbUt878-edit
   access:
   - Maintenance
   - Engineering
@@ -32,8 +32,6 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -21,7 +21,7 @@
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Edit-by-RaMbUt878
   radioBold: true # Sunrise-Edit
   displayWeight: 60 # Sunrise-Edit
   access:
@@ -33,8 +33,6 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -13,7 +13,7 @@
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"
   supervisors: job-supervisors-captain
-  canBeAntag: false
+  canBeAntag: true # Edit-by-RaMbUt878
   radioBold: true # Sunrise-Edit
   displayWeight: 50 # Sunrise-Edit
   access:
@@ -24,8 +24,6 @@
   - Brig
   - Cryogenics
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Я бы хотел добавить старую механику с СС13, где ГП, НР, ГВ, СИ, КМ Могли быть антагонистами, но ГСБ, Кэп, и наши другие роли с Санрайза не могли.

## По какой причине
Пока оффы не добавили, то почему нет? На главах будут играть всё больше и больше, онлайн будет на них расти, каждую смену будут фулл главы.

## Медиа(Видео/Скриншоты)


## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**


:cl: RaMbUt878
- add: Глава Персонала, КМ, НР, ГВ и СИ больше не имеют МШ и могут стать антагонистами.
