### PR TITLE
Фикс коллизии турелей

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -43,8 +43,8 @@
       fixtures:
         fix1:
           shape:
-            !type:PhysShapeAabb
-            bounds: "-0.45,-0.45,0.45,0.45"
+            !type:PhysShapeCircle
+            radius: 0.45
           density: 60
           mask:
             - MachineMask


### PR DESCRIPTION
## Кратное описание
Фиксанул коллизию турелек.

## По какой причине
Из-за их квадратной коллизии, часто застревали мехи и не могли закрыть шлюзы.

## Медиа(Видео/Скриншоты)
Было:
![image](https://github.com/user-attachments/assets/432838f6-1f4a-4ab0-9c6a-f1a257ab8033)
Стало:
![image](https://github.com/user-attachments/assets/a7acf598-d41c-49a2-903d-710f94d049c9)

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: Parashut
- fix: Исправлена коллизия всех турелей.
