### PR TITLE
Фикс Фракций

### DIFF
--- a/Resources/Prototypes/_Sunrise/ai_factions.yml
+++ b/Resources/Prototypes/_Sunrise/ai_factions.yml
@@ -3,7 +3,10 @@
   hostile:
   - NanoTrasen
   - Syndicate
+  - SimpleHostile
+  - Xeno
   - Zombie
+  - PetsNT
   - Revolutionary
   - AllHostile
   - Thief
@@ -14,9 +17,9 @@
   id: Thief
   hostile:
   - NanoTrasen
+  - Syndicate
   - SimpleHostile
   - Xeno
-  - PetsNT
   - Zombie
   - AllHostile
   - Carps
@@ -28,9 +31,10 @@
   hostile:
   - NanoTrasen
   - Syndicate
+  - SimpleHostile
+  - Zombie
   - Xeno
   - PetsNT
-  - Zombie
   - Revolutionary
   - AllHostile
   - Thief
@@ -42,9 +46,11 @@
   hostile:
   - NanoTrasen
   - Syndicate
+  - SimpleHostile
   - Zombie
-  - Revolutionary
   - Xeno
+  - PetsNT
+  - Revolutionary
   - AllHostile
   - Thief
   - Carps

--- a/Resources/Prototypes/_Sunrise/ai_factions.yml
+++ b/Resources/Prototypes/_Sunrise/ai_factions.yml
@@ -1,4 +1,3 @@
-
 - type: npcFaction
   id: Changeling
   hostile:

--- a/Resources/Prototypes/_Sunrise/ai_factions.yml
+++ b/Resources/Prototypes/_Sunrise/ai_factions.yml
@@ -1,0 +1,52 @@
+
+- type: npcFaction
+  id: Changeling
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - Zombie
+  - Revolutionary
+  - AllHostile
+  - Thief
+  - Carps
+  - Vampire
+
+- type: npcFaction
+  id: Thief
+  hostile:
+  - NanoTrasen
+  - SimpleHostile
+  - Xeno
+  - PetsNT
+  - Zombie
+  - AllHostile
+  - Carps
+  - Changeling
+  - Vampire
+
+- type: npcFaction
+  id: Carps
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - Xeno
+  - PetsNT
+  - Zombie
+  - Revolutionary
+  - AllHostile
+  - Thief
+  - Vampire
+  - Changeling
+
+- type: npcFaction
+  id: Vampire
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - Zombie
+  - Revolutionary
+  - Xeno
+  - AllHostile
+  - Thief
+  - Carps
+  - Changeling

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -1,29 +1,23 @@
 - type: npcFaction
-  id: Carps
-  hostile:
-    - NanoTrasen
-    - Syndicate
-    - Thief
-    - Xeno
-    - PetsNT
-    - Zombie
-    - Revolutionary
-    - SimpleHostile
-
-- type: npcFaction
   id: NanoTrasen
   hostile:
   - SimpleHostile
   - Syndicate
-  - Thief
   - Xeno
   - Zombie
   - Revolutionary
+  - AllHostile
+  # SunRise Edit
+  - Thief 
+  - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: Mouse
   hostile:
     - PetsNT
+    - AllHostile
 
 - type: npcFaction
   id: Passive
@@ -35,18 +29,25 @@
   - SimpleHostile
   - Zombie
   - Xeno
+  - AllHostile
+  # SunRise Edit
+  - Carps
 
 - type: npcFaction
   id: SimpleHostile
   hostile:
   - NanoTrasen
   - Syndicate
-  - Thief
   - Passive
   - PetsNT
   - Zombie
   - Revolutionary
+  - AllHostile
+  # SunRise Edit
+  - Thief
   - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: SimpleNeutral
@@ -59,26 +60,28 @@
   - Xeno
   - PetsNT
   - Zombie
-
-- type: npcFaction
-  id: Thief
-  hostile:
-  - NanoTrasen
-  - SimpleHostile
-  - Xeno
-  - PetsNT
-  - Zombie
+  - AllHostile
+  # SunRise Edit
+  - Thief
+  - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: Xeno
   hostile:
   - NanoTrasen
   - Syndicate
-  - Thief
   - Passive
   - PetsNT
   - Zombie
   - Revolutionary
+  - AllHostile
+  # SunRise Edit
+  - Thief
+  - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: Zombie
@@ -87,10 +90,13 @@
   - SimpleNeutral
   - SimpleHostile
   - Syndicate
-  - Thief
   - Passive
   - PetsNT
   - Revolutionary
+  - AllHostile
+  # SunRise Edit
+  - Thief
+  - Carps
   - Changeling
   - Vampire
 
@@ -100,24 +106,27 @@
   - NanoTrasen
   - Zombie
   - SimpleHostile
+  - AllHostile
+  # SunRise Edit
   - Carps
-
-- type: npcFaction
-  id: Changeling
-  hostile:
-  - NanoTrasen
-  - Syndicate
-  - Thief
-  - Zombie
-  - Revolutionary
-
-- type: npcFaction
-  id: Vampire
-  hostile:
-  - NanoTrasen
-  - Syndicate
-  - Thief
-  - Zombie
-  - Revolutionary
+  - Vampire
   - Changeling
+
+- type: npcFaction
+  id: AllHostile
+  hostile:
+  - NanoTrasen
+  - Mouse
+  - Passive
+  - PetsNT
+  - SimpleHostile
+  - SimpleNeutral
+  - Syndicate
   - Xeno
+  - Zombie
+  - Revolutionary
+  # SunRise Edit
+  - Thief
+  - Carps
+  - Changeling
+  - Vampire


### PR DESCRIPTION
## Кратное описание
Вынес кастомные фракции в отдельный файлик в папке "_Sunrise".
Объявил войну между Карпами, Генокрадами, Вампирами, Ворами и Синдикатовцами.

## По какой причине
Убрал нелогишности.
Карпы не ели генокрадов, турели Синдиката не стреляли воришек и т.п.

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: Parashut
- fix: Исправлены взаимодействия фракций.
- tweak: Теперь Карпы, Генокрады, Вампиры, Воры и Синдикат в состоянии войны!
