### PR TITLE
Фикс взаимоотношений фракций

### DIFF
--- a/Resources/Prototypes/_Sunrise/ai_factions.yml
+++ b/Resources/Prototypes/_Sunrise/ai_factions.yml
@@ -1,0 +1,57 @@
+- type: npcFaction
+  id: Changeling
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - SimpleHostile
+  - Xeno
+  - Zombie
+  - PetsNT
+  - Revolutionary
+  - AllHostile
+  - Thief
+  - Carps
+  - Vampire
+
+- type: npcFaction
+  id: Thief
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - SimpleHostile
+  - Xeno
+  - Zombie
+  - AllHostile
+  - Carps
+  - Changeling
+  - Vampire
+
+- type: npcFaction
+  id: Carps
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - SimpleHostile
+  - Zombie
+  - Xeno
+  - PetsNT
+  - Revolutionary
+  - AllHostile
+  - Thief
+  - Vampire
+  - Changeling
+
+- type: npcFaction
+  id: Vampire
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - SimpleHostile
+  - Zombie
+  - Xeno
+  - PetsNT
+  - Revolutionary
+  - AllHostile
+  - Thief
+  - Carps
+  - Changeling

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -3,12 +3,15 @@
   hostile:
   - SimpleHostile
   - Syndicate
-  - Thief
   - Xeno
   - Zombie
   - Revolutionary
-  - Carps
   - AllHostile
+  # Sunrise Edit
+  - Thief
+  - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: Mouse
@@ -27,19 +30,24 @@
   - Zombie
   - Xeno
   - AllHostile
+  # Sunrise Edit
+  - Carps
 
 - type: npcFaction
   id: SimpleHostile
   hostile:
   - NanoTrasen
   - Syndicate
-  - Thief
   - Passive
   - PetsNT
   - Zombie
   - Revolutionary
   - AllHostile
+  # Sunrise Edit
+  - Thief
   - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: SimpleNeutral
@@ -52,29 +60,28 @@
   - Xeno
   - PetsNT
   - Zombie
-  - Carps
   - AllHostile
-
-- type: npcFaction
-  id: Thief
-  hostile:
-  - NanoTrasen
-  - SimpleHostile
-  - Xeno
-  - PetsNT
-  - Zombie
+  # Sunrise Edit
+  - Thief
+  - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: Xeno
   hostile:
   - NanoTrasen
   - Syndicate
-  - Thief
   - Passive
   - PetsNT
   - Zombie
   - Revolutionary
   - AllHostile
+  # Sunrise Edit
+  - Thief
+  - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: Zombie
@@ -83,11 +90,13 @@
   - SimpleNeutral
   - SimpleHostile
   - Syndicate
-  - Thief
   - Passive
   - PetsNT
   - Revolutionary
   - AllHostile
+  # Sunrise Edit
+  - Thief
+  - Carps
   - Changeling
   - Vampire
 
@@ -97,15 +106,16 @@
   - NanoTrasen
   - Zombie
   - SimpleHostile
-  - Carps
-  - Carps
   - AllHostile
+  # Sunrise Edit
+  - Carps
+  - Changeling
+  - Vampire
 
 - type: npcFaction
   id: AllHostile
   hostile:
   - NanoTrasen
-  - Carps
   - Mouse
   - Passive
   - PetsNT
@@ -115,38 +125,8 @@
   - Xeno
   - Zombie
   - Revolutionary
+  # Sunrise Edit
+  - Thief
+  - Carps
   - Changeling
   - Vampire
-
-- type: npcFaction
-  id: Changeling
-  hostile:
-  - NanoTrasen
-  - Syndicate
-  - Thief
-  - Zombie
-  - Revolutionary
-  - Vampire
-
-- type: npcFaction
-  id: Vampire
-  hostile:
-  - NanoTrasen
-  - Syndicate
-  - Thief
-  - Zombie
-  - Revolutionary
-  - Changeling
-  - Xeno
-
-- type: npcFaction
-  id: Carps
-  hostile:
-  - NanoTrasen
-  - Syndicate
-  - Thief
-  - Xeno
-  - PetsNT
-  - Zombie
-  - Revolutionary
-  - AllHostile


### PR DESCRIPTION
## Кратное описание
Вынес кастомные фракции в отдельный файлик в папке "_Sunrise".
Объявил войну между Карпами, Генокрадами, Вампирами, Ворами и Синдикатовцами.
Так же: 
- Зомби кушают карпов. 
- Ксено атакует Гено, Вампиров и Воров.

## По какой причине
Убрал нелогишности.
Карпы не ели генокрадов, турели Синдиката не стреляли воришек и т.п.

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: Parashut
- fix: Исправлены взаимодействия фракций.
- tweak: Теперь Карпы, Генокрады, Вампиры, Воры и Синдикат в состоянии войны!
