### PR TITLE
ERT: Только Люди

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -222,6 +222,7 @@
   - Tajaran
   - Demon
   - SlimePerson
+  - Dwarf
   parent: ERTLeader
   components:
     - type: BibleUser
@@ -266,6 +267,7 @@
   - Tajaran
   - Demon
   - SlimePerson
+  - Dwarf
   parent: ERTChaplain
   components:
     - type: GhostRole
@@ -312,6 +314,7 @@
   - Tajaran
   - Demon
   - SlimePerson
+  - Dwarf
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -355,6 +358,7 @@
   - Tajaran
   - Demon
   - SlimePerson
+  - Dwarf
   parent: ERTJanitor
   components:
     - type: GhostRole
@@ -400,6 +404,7 @@
   - Tajaran
   - Demon
   - SlimePerson
+  - Dwarf
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -443,6 +448,7 @@
   - Tajaran
   - Demon
   - SlimePerson
+  - Dwarf
   parent: ERTEngineer
   components:
     - type: GhostRole

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -42,6 +42,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: EventHumanoidMindShielded
   randomizeName: false
   components:
@@ -88,6 +92,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: EventHumanoidMindShielded
   randomizeName: false
   components:
@@ -129,6 +137,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -161,6 +173,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: ERTLeaderEVA
   components:
     - type: GhostRole
@@ -203,6 +219,9 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
   parent: ERTLeader
   components:
     - type: BibleUser
@@ -244,6 +263,9 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
   parent: ERTChaplain
   components:
     - type: GhostRole
@@ -287,6 +309,9 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -327,6 +352,9 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
   parent: ERTJanitor
   components:
     - type: GhostRole
@@ -369,6 +397,9 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -409,6 +440,9 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
   parent: ERTEngineer
   components:
     - type: GhostRole
@@ -451,6 +485,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -491,6 +529,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: ERTSecurity
   components:
     - type: GhostRole
@@ -523,6 +565,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: ERTSecurityEVA
   components:
     - type: GhostRole
@@ -565,6 +611,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -605,6 +655,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: ERTMedical
   components:
     - type: GhostRole
@@ -642,6 +696,10 @@
   - Reptilian
   - Vulpkanin
   - Swine
+  - Tajaran
+  - Demon
+  - SlimePerson
+  - Dwarf
   parent: EventHumanoidMindShielded
   components:
     - type: Loadout

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -20,7 +20,6 @@
     jumpsuit: ClothingUniformJumpsuitERTLeader
     back: ClothingBackpackERTLeader
     shoes: ClothingShoesSwat # Sunrise-edit
-    mask: ClothingMaskGasERT # Sunrise-edit
     head: ClothingHeadEVAHelmetERTLeader  # Sunrise-edit
     eyes: ClothingEyesGlassesSecurity
     gloves: ClothingHandsGlovesCombat
@@ -29,14 +28,14 @@
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltSecurityFilled
     pocket1: WeaponPistolN1984
-    pocket2: MagazineMagnum
+    pocket2: HandheldCriminalRecordsMonitorUnpowered # Sunrise-edit
   storage:
     back:
     - WeaponEnergyGunPistolSecurity # Sunrise-edit
     - PortableSurveillanceCameraMonitorUnpowered # Sunrise-edit
     - MedicatedSuture
     - RegenerativeMesh
-    - BoxZiptie
+    #- BoxZiptie # Sunrise-edit
     - CrowbarRed
     - MagazineMagnum
     - ERTDirectivesCircuitBoard # Sunrise-edit
@@ -61,7 +60,7 @@
     - WeaponEnergyGunPistolSecurity # Sunrise-edit
     - MedicatedSuture
     - RegenerativeMesh
-    - BoxZiptie
+    #- BoxZiptie # Sunrise-edit
     - CrowbarRed
     - PortableSurveillanceCameraMonitorUnpowered # Sunrise-edit
     - MagazineMagnum
@@ -89,7 +88,7 @@
     - WeaponDisabler
     - MedicatedSuture
     - RegenerativeMesh
-    - BoxZiptie
+    #- BoxZiptie # Sunrise-edit
     - CrowbarRed
     - MagazineMagnum
     - ERTDirectivesCircuitBoard # Sunrise-edit
@@ -121,25 +120,23 @@
     back: ClothingBackpackERTChaplain
     shoes: ClothingShoesSwat # Sunrise-edit
     head: ClothingHeadEVAHelmetERTChaplain # Sunrise-edit
-    eyes: ClothingEyesGlasses
+    eyes: ClothingEyesHudMedSec # Sunrise-edit
     neck: ClothingNeckStoleChaplain
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterArmorAmberChap # Sunrise-edit
     id: ERTChaplainPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltStorageWaistbag
-    pocket1: Flare
+    pocket1: CrowbarRed # Sunrise-edit
     pocket2: DrinkWaterBottleFull
   storage:
     back:
     - BoxCandle
-    - BoxBodyBag
-    - DrinkWaterMelonJuiceJug
+    #-BoxBodyBag # Sunrise-edit
     - Lantern
     - Lantern
     - Bible
-    - CrowbarRed
-    - FoodBakedBunHotX
+    - MegaSprayBottle # Sunrise-edit
     - FoodBakedBunHotX
     - FoodBakedBunHotX
     - FoodBakedBunHotX
@@ -152,25 +149,23 @@
     back: ClothingBackpackERTChaplain
     shoes: ClothingShoesBootsMagAdv
     mask: ClothingMaskGasERT
-    eyes: ClothingEyesGlasses
+    eyes: ClothingEyesHudMedSec # Sunrise-edit
     neck: ClothingNeckStoleChaplain
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterHardsuitERTChaplain
     id: ERTChaplainPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltStorageWaistbag
-    pocket1: Flare
+    pocket1: CrowbarRed # Sunrise-edit
     pocket2: DrinkWaterBottleFull
   storage:
     back:
     - BoxCandle
-    - BoxBodyBag
-    - DrinkWaterMelonJuiceJug
+    #-BoxBodyBag # Sunrise-edit
     - Lantern
     - Lantern
     - Bible
-    - CrowbarRed
-    - FoodBakedBunHotX
+    - MegaSprayBottle # Sunrise-edit
     - FoodBakedBunHotX
     - FoodBakedBunHotX
     - FoodBakedBunHotX
@@ -197,8 +192,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitERTEngineer
     back: ClothingBackpackERTEngineer
-    shoes: ClothingShoesSwat # Sunrise-edit
-    mask: ClothingMaskGasERT # Sunrise-edit
+    shoes: ClothingShoesBootsMagCombat # Sunrise-edit
     head: ClothingHeadEVAHelmetERTEngineer # Sunrise-edit
     eyes: ClothingEyesHudDiagnosticERT # Sunrise-edit
     gloves: ClothingHandsGlovesCombat
@@ -211,12 +205,12 @@
   storage:
     back:
     # - trayScanner # Sunrise-edit
-    - RCD
-    - RCDAmmo
-    - RCDAmmo
-    - CableMVStack
-    - CableHVStack
-    - CableApcStack
+    - RCDRecharging
+    #- RCDAmmo  # Sunrise-edit
+    #- RCDAmmo  # Sunrise-edit
+    #- CableMVStack # Sunrise-edit
+    #- CableHVStack # Sunrise-edit
+    #- CableApcStack  # Sunrise-edit
     - SheetPlasteel
     - SheetSteel
     - SheetGlass
@@ -239,12 +233,12 @@
   storage:
     back:
     # - trayScanner # Sunrise-edit
-    - RCD
-    - RCDAmmo
-    - RCDAmmo
-    - CableMVStack
-    - CableHVStack
-    - CableApcStack
+    - RCDRecharging
+    #- RCDAmmo  # Sunrise-edit
+    #- RCDAmmo  # Sunrise-edit
+    #- CableMVStack # Sunrise-edit
+    #- CableHVStack # Sunrise-edit
+    #- CableApcStack  # Sunrise-edit
     - SheetPlasteel
     - SheetSteel
     - SheetGlass
@@ -271,7 +265,6 @@
     jumpsuit: ClothingUniformJumpsuitERTSecurity
     back: ClothingBackpackERTSecurity
     shoes: ClothingShoesSwat # Sunrise-edit
-    mask: ClothingMaskGasERT # Sunrise-edit
     head: ClothingHeadEVAHelmetERTSecurity  # Sunrise-edit
     eyes: ClothingEyesGlassesSecurity
     gloves: ClothingHandsGlovesCombat
@@ -286,7 +279,7 @@
     - WeaponEnergyGunPistolSecurity # Sunrise-edit
     - MedicatedSuture
     - RegenerativeMesh
-    - BoxZiptie
+    #- BoxZiptie # Sunrise-edit
     - CrowbarRed
     - MagazineMagnum # Sunrise-edit
 
@@ -310,7 +303,7 @@
     - WeaponEnergyGunPistolSecurity # Sunrise-edit
     - MedicatedSuture
     - RegenerativeMesh
-    - BoxZiptie
+    #- BoxZiptie # Sunrise-edit
     - CrowbarRed
     - MagazineMagnum # Sunrise-edit
 
@@ -336,7 +329,7 @@
     - WeaponDisabler
     - MedicatedSuture
     - RegenerativeMesh
-    - BoxZiptie
+    #- BoxZiptie # Sunrise-edit
     - CrowbarRed
     - MagazinePistol
 
@@ -362,7 +355,6 @@
     jumpsuit: ClothingUniformJumpsuitERTMedic
     back: ClothingBackpackERTMedical
     shoes: ClothingShoesSwat # Sunrise-edit
-    mask: ClothingMaskGasERT # Sunrise-edit
     head: ClothingHeadEVAHelmetERTMedic # Sunrise-edit
     eyes: ClothingEyesHudMedSec # Sunrise-edit
     gloves: ClothingHandsGlovesCombat # Sunrise-edit
@@ -375,7 +367,7 @@
   storage:
     back:
     - Hypospray
-    - MedkitAdvancedFilled
+    #- MedkitAdvancedFilled # Sunrise-edit
     - CrowbarRed
     - OmnizineChemistryBottle
     - EpinephrineChemistryBottle
@@ -402,7 +394,7 @@
   storage:
     back:
     - Hypospray
-    - MedkitAdvancedFilled
+    #- MedkitAdvancedFilled # Sunrise-edit
     - CrowbarRed
     - OmnizineChemistryBottle
     - EpinephrineChemistryBottle
@@ -433,21 +425,22 @@
     jumpsuit: ClothingUniformJumpsuitERTJanitor
     back: ClothingBackpackERTJanitor
     shoes: ClothingShoesGaloshes
-    mask: ClothingMaskGasERT # Sunrise-edit
     head: ClothingHeadEVAHelmetERTJanitor # Sunrise-edit
+    eyes: ClothingEyesGlassesSecurity # Sunrise-edit
     gloves: ClothingHandsGlovesCombat # Sunrise-edit
     outerClothing: ClothingOuterArmorAmberJan
     id: ERTJanitorPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltJanitorFilled
     pocket1: WeaponEnergyGunPistolSecurity # Sunrise-edit
+    pocket2: CrowbarRed # Sunrise-edit
   storage:
     back:
     - LightReplacer
     - BoxLightMixed
-    - BoxLightMixed
-    - Soap
-    - CrowbarRed
+    #- BoxLightMixed # Sunrise-edit
+    #- Soap # Sunrise-edit
+    #- CrowbarRed # Sunrise-edit
     - AdvMopItem
 
 - type: startingGear
@@ -457,17 +450,20 @@
     back: ClothingBackpackERTJanitor
     shoes: ClothingShoesBootsMagCombat
     mask: ClothingMaskGasERT
+    eyes: ClothingEyesGlassesSecurity # Sunrise-edit
     gloves: ClothingHandsGlovesCombat # Sunrise-edit
     outerClothing: ClothingOuterHardsuitERTJanitor
     id: ERTJanitorPDA
     ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltJanitorFilled
     pocket1: WeaponEnergyGunPistolSecurity # Sunrise-edit
+    pocket2: CrowbarRed # Sunrise-edit
   storage:
     back:
     - LightReplacer
     - BoxLightMixed
-    - BoxLightMixed
-    - Soap
+    #- BoxLightMixed # Sunrise-edit
+    #- Soap # Sunrise-edit
+    #- CrowbarRed # Sunrise-edit
     - CrowbarRed
     - AdvMopItem

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Head/helmets.yml
@@ -90,7 +90,8 @@
     tags:
     - WhitelistChameleon
     - HelmetEVA
-  - type: IdentityBlocker
+  - type: FlashImmunity
+  - type: EyeProtection
   - type: HideLayerClothing
     slots:
     - Hair


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
1) Теперь ОБР и Эскадрон только люди (Иногда Дворф)
2) Фикс содержимого рюкзаков ОБР
## По какой причине
Одежда создана под людей без лишних выпирающих вещей (Ушей,хвостов, Носов) больше не будет розового тайяра или вульпы на ЛОБРе. Так же это Унификация лечения, кислорода и тд. и Лорно для НТ

При спавне ролей постоянно выпадали Аварийные наборы, я изменил содержимое так чтобы не падала эффективность и набор был в рюкзаке а не под бойцом


## Медиа(Видео/Скриншоты)
Нечего

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: KaiserMaus
- tweak: ОБР и Эскадрон теперь только Люди.
- fix: Исправлены аварийные наборы для ОБР.

