### PR TITLE
FireLock improve

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -27,7 +27,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 500
+          damage: 300 # Sunrise-edit
         behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]


### PR DESCRIPTION
#973 

:cl: Babaev
- tweak: Теперь пожарные шлюзы автоматически открываются при отсутствии разгерметизации.
- tweak: Теперь пожарная сигнализация автоматически отключает режим аварийного доступа на шлюзах при активации.
- tweak: Уменьшена прочность пожарных шлюзов с 500 до 300 единиц урона, теперь их легче сломать.