### PR TITLE
Очки ОСЩа показывают МЩ + Сварочные Очки не защищают от вспышек

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Eyes/glasses.yml
@@ -21,7 +21,7 @@
       sprite: _Sunrise/Clothing/Eyes/Glasses/kim.rsi
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: [ClothingEyesBase, ShowSecurityIcons, BaseRestrictedContraband]
   id: ClothingEyesGlassesBlueShield
   name: blueshield's glasses
   description: The innovative blue lenses hide your eyes from light flashes and have a built-in visor.
@@ -55,7 +55,7 @@
     sprite: _Sunrise/Clothing/Eyes/Glasses/weldglasses.rsi
   - type: Clothing
     sprite: _Sunrise/Clothing/Eyes/Glasses/weldglasses.rsi
-  - type: FlashImmunity
+  #- type: FlashImmunity
   - type: EyeProtection
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Очки ОСЩа показывают МЩ + Сварочные Очки не защищают от вспышек

## По какой причине
Мне кажется просто забыли что у ОСЩа свои очки

Сварочные очки манчат антагонисты, слишком просто получить защиту от вспышек что контрит базовые нелетальные средства СБ
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: KaiserMaus
- tweak: Сварочные Очки больше не защищают от вспышек.
- fix: Очки ОСЩ показывают наличие МЩ.

