### PR TITLE
Фикс целей генокрадов

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -217,9 +217,9 @@
         maxVol: 20
         reagents:
         - ReagentId: Bicaridine
-          Quantity: 15
+          Quantity: 14
         - ReagentId: TranexamicAcid
-          Quantity: 5
+          Quantity: 6
   - type: Tag
     tags: []
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -217,9 +217,9 @@
         maxVol: 20
         reagents:
         - ReagentId: Bicaridine
-          Quantity: 14
+          Quantity: 14 #Sunrise-edit
         - ReagentId: TranexamicAcid
-          Quantity: 6
+          Quantity: 6 #Sunrise-edit
   - type: Tag
     tags: []
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -217,9 +217,9 @@
         maxVol: 20
         reagents:
         - ReagentId: Bicaridine
-          Quantity: 14 #Sunrise-edit
+          Quantity: 15
         - ReagentId: TranexamicAcid
-          Quantity: 6 #Sunrise-edit
+          Quantity: 5
   - type: Tag
     tags: []
 

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -48,7 +48,8 @@
   - type: ChangelingRule
   - type: AntagObjectives
     objectives:
-    - VampireDrainObjective
+    - ChangelingStealDNAObjective
+    - ChangelingSurviveObjective
   - type: AntagRandomObjectives
     sets:
     - groups: ChangelingObjectiveGroups

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -46,6 +46,13 @@
       min: 600
       max: 900
   - type: ChangelingRule
+  - type: AntagObjectives
+    objectives:
+    - VampireDrainObjective
+  - type: AntagRandomObjectives
+    sets:
+    - groups: ChangelingObjectiveGroups
+    maxDifficulty: 10
   - type: AntagSelection
     agentName: changeling-roundend-name
     definitions:

--- a/Resources/Prototypes/Objectives/changeling.yml
+++ b/Resources/Prototypes/Objectives/changeling.yml
@@ -22,6 +22,35 @@
       sprite: Changeling/changeling_abilities.rsi
       state: stasis_exit
 
+#Kill
+- type: entity
+  parent: [BaseChangelingObjective, BaseKillObjective]
+  id: ChangelingKillRandomPersonObjective
+  description: Do it however you like, just make sure they don't make it to centcomm.
+  components:
+  - type: Objective
+    difficulty: 1.75
+    unique: false
+  - type: TargetObjective
+    title: objective-condition-kill-person-title
+  - type: PickRandomPerson
+  - type: KillPersonCondition
+    requireDead: true
+
+- type: entity
+  parent: [BaseChangelingObjective, BaseKillObjective]
+  id: ChangelingKillRandomAntagObjective
+  description:
+  components:
+  - type: Objective
+    difficulty: 3.0
+    unique: true
+  - type: TargetObjective
+    title: objective-condition-kill-antag-title
+  - type: PickRandomAntag
+  - type: KillPersonCondition
+    requireDead: true
+
 - type: entity
   parent: BaseChangelingObjective
   id: ChangelingAbsorbObjective

--- a/Resources/Prototypes/_Sunrise/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Sunrise/Objectives/objectiveGroups.yml
@@ -51,13 +51,11 @@
 - type: weightedRandom
   id: ChangelingObjectiveGroupKill
   weights:
-    ChangelingKillRandomPersonObjective: 1
-    ChangelingKillRandomAntagObjective: 0.3
+    ChangelingKillRandomAntagObjective: 1
+    ChangelingKillRandomPersonObjective: 0.3
 
 - type: weightedRandom
   id: ChangelingObjectiveGroupState
   weights:
-    ChangelingSurviveObjective: 1
     ChangelingAbsorbObjective: 1
-    ChangelingStealDNAObjective: 1
     EscapeIdentityObjective: 1

--- a/Resources/Prototypes/_Sunrise/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Sunrise/Objectives/objectiveGroups.yml
@@ -28,3 +28,36 @@
   weights:
     VampireSurviveObjective: 1
     VampireEscapeObjective: 1
+
+- type: weightedRandom
+  id: ChangelingObjectiveGroups
+  weights:
+    ChangelingObjectiveGroupSteal: 1
+    ChangelingObjectiveGroupKill: 1
+    ChangelingObjectiveGroupState: 1
+
+- type: weightedRandom
+  id: ChangelingObjectiveGroupSteal
+  weights:
+    CMOHyposprayChangelingStealObjective: 1
+    RDHardsuitChangelingStealObjective: 1
+    EnergyShotgunChangelingStealObjective: 1
+    MagbootsChangelingStealObjective: 1
+    ClipboardChangelingStealObjective: 1
+    CaptainIDChangelingStealObjective: 1
+    CaptainJetpackChangelingStealObjective: 1
+    CaptainGunChangelingStealObjective: 1
+
+- type: weightedRandom
+  id: ChangelingObjectiveGroupKill
+  weights:
+    ChangelingKillRandomPersonObjective: 1
+    ChangelingKillRandomAntagObjective: 0.3
+
+- type: weightedRandom
+  id: ChangelingObjectiveGroupState
+  weights:
+    ChangelingSurviveObjective: 1
+    ChangelingAbsorbObjective: 1
+    ChangelingStealDNAObjective: 1
+    EscapeIdentityObjective: 1


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Фикс целей генокрадов, теперь они выпадают (сделано на базе вампирских)

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
![1](https://github.com/user-attachments/assets/e89d895e-f754-4521-b0c1-60e2ee9afc2d)

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: Генокрады теперь получают цели на убийства и кражу.