### PR TITLE
Повышение количества кабелей в электротехническом тулбоксе

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -34,14 +34,14 @@
       - id: Screwdriver
       - id: CrowbarOrange
       - id: Wirecutter
-      - id: CableApcStack10
-      - id: CableMVStack10
+      - id: CableApcStack
+      - id: CableMVStack
       - id: trayScanner
         prob: 0.9
       - id: ClothingHandsGlovesColorYellow
         prob: 0.05
         orGroup: GlovesOrWires
-      - id: CableHVStack10
+      - id: CableHVStack
         orGroup: GlovesOrWires
 
 - type: entity
@@ -55,14 +55,14 @@
       - id: Screwdriver
       - id: CrowbarOrange
       - id: Wirecutter
-      - id: CableApcStack10
-      - id: CableMVStack10
+      - id: CableApcStack
+      - id: CableMVStack
       - id: trayScanner
         prob: 0.9
       - id: ClothingHandsGlovesColorYellow
         prob: 0.05
         orGroup: GlovesOrWires
-      - id: CableHVStack10
+      - id: CableHVStack
         orGroup: GlovesOrWires
 
 - type: entity


### PR DESCRIPTION
## Кратное описание
Повышение количества кабелей в электро тулбоксе

## По какой причине
Оффы в 2023 шаманили в инвентарем, когда тот ещё был в виде таблицы, сделали так, что бы 1 кабель занимал 1 место. А в тулбоксе вместимость было 0/60, кажется. И что бы все кабели вмещались, их сделали по 10. Когда эта проблема решилась с новым инвентарем, оффы забили хуй на кабеля . 

## Медиа(Видео/Скриншоты)

![Снимок экрана (3650)](https://github.com/user-attachments/assets/54b3d4a3-5a0d-4359-b653-74f4a21455ba)

## Проверки

- [ ] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: Kinar7
- tweak: повышенно количество всех типов кабелей в электротехнических тулбоксах
