### PR TITLE
Суперматерию больше нельзя открепить гаечным ключом

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
@@ -31,8 +31,6 @@
       enabled: false
     - type: Clickable
     - type: InteractionOutline
-    - type: Anchorable
-    - type: Pullable
     - type: Sprite
       drawdepth: 2
       sprite: Structures/Power/Generation/supermatter.rsi


### PR DESCRIPTION
#1033 

🆑 Babaev

- fix: Суперматерию больше нельзя открепить гаечным ключом.