### PR TITLE
Революция теперь заканчивается сразу после убийства всех глав

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -11,6 +11,7 @@ using Content.Server.Roles;
 using Content.Server.RoundEnd;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Systems;
+using Content.Server.AlertLevel; // Sunrise-Edit
 using Content.Shared.Database;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Humanoid;
@@ -49,6 +50,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;
     [Dependency] private readonly StationSystem _stationSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly AlertLevelSystem _alertLevel = default!; // Sunrise-Edit
 
     //Used in OnPostFlash, no reference to the rule component is available
     public readonly ProtoId<NpcFactionPrototype> RevolutionaryNpcFaction = "Revolutionary";
@@ -81,7 +83,14 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
             if (CheckCommandLose())
             {
-                _roundEnd.EndRound(); //  Sunrise-Edit
+                //  Sunrise-Edit-Start
+                var stations = _stationSystem.GetStations();
+                foreach (var station in stations)
+                {
+                    _alertLevel.SetLevel(station, "epsilon", true, true, true);
+                }
+                _roundEnd.EndRound();
+                //  Sunrise-Edit-End
                 GameTicker.EndGameRule(uid, gameRule);
             }
         }

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -81,7 +81,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
             if (CheckCommandLose())
             {
-                _roundEnd.DoRoundEndBehavior(RoundEndBehavior.ShuttleCall, component.ShuttleCallTime);
+                _roundEnd.EndRound(); //  Sunrise-Edit
                 GameTicker.EndGameRule(uid, gameRule);
             }
         }


### PR DESCRIPTION
:cl: Babaev
- tweak: Революция теперь заканчивается манифестом, сразу после убийства всех глав, без вызова эвакуационного шаттла. При этом автоматически устанавливается уровень угрозы Эпсилон.