### PR TITLE
Безопасность: Балансные правки

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -6,11 +6,11 @@
     ClothingShoesColorBrown: 2
     ClothingOuterCoatDetectiveLoadout: 1
     ClothingOuterCoatDetectiveLoadoutGrey: 1
-    ClothingOuterCoatDetectiveDark: 2
+    ClothingOuterCoatDetectiveDark: 1
     ClothingHeadHatFedoraBrown: 2
     ClothingUniformJumpsuitDetectiveGrey: 2
     ClothingUniformJumpskirtDetectiveGrey: 2
-    ClothingOuterVestDetective: 2
+    ClothingOuterVestDetective: 1
     ClothingNeckTieDet: 2
     ClothingHeadHatFedoraGrey: 2
     ClothingHandsGlovesColorBlack: 2

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -66,9 +66,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
+        Blunt: 0.65 #sunrise-start
+        Slash: 0.65
+        Piercing: 0.6 #sunrise-end
         Heat: 0.7
         Caustic: 0.75 # not the full 90% from ss13 because of the head
   - type: ExplosionResistance
@@ -82,10 +82,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
+        Blunt: 0.65 #sunrise-edit
+        Slash: 0.65 #sunrise-edit
+        Piercing: 0.65 #sunrise-edit
         Heat: 0.7
+        Caustic: 0.75 #sunrise-edit
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -290,8 +290,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5 #sunrise-edit
+        Blunt: 0.45 #sunrise-edit
+        Slash: 0.45 #sunrise-edit
         Piercing: 0.6
         Heat: 0.65 #sunrise-edit
         Caustic: 0.7

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -34,7 +34,7 @@
   - type: PowerCellVisuals
   - type: Riggable
   - type: HitscanBatteryAmmoProvider
-    proto: BulletRedLightLaser # Sunrise-Edit
+    proto: BulletRedLaser # Sunrise-Edit
     fireCost: 50
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -368,7 +368,7 @@
       - EnergyDomeDirectionalTurtle
       # Sunrise-start
       - PowerCellHyper
-      - ClothingHeadHelmetPubgMore
+      - ClothingHeadHelmetPubg
       - MechPhasicScanningModule
       - HandCraftedNVD
       - BasicNVD

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -933,8 +933,6 @@
       - MagazineBoxMagnumRubber
       - MagazineBoxRifleRubber
       - MagazineBoxLightRifleRubber
-      - MagazineLightRifleBoxIncendiary
-      - MagazineLightRifleBoxUranium
       - PowerCageCombat
       - WeaponMechCombatImmolationGun # Sunrise - Mechs
       - WeaponMechCombatSolarisLaser # Sunrise - Mechs

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -117,7 +117,7 @@
   - TelescopicShield
   - HoloprojectorSecurity
   - WeaponDisablerSMG
-  - ClothingHeadHelmetPubgMore  # Sunrise-edit
+  - ClothingHeadHelmetPubg  # Sunrise-edit
 
 - type: technology
   id: ExplosiveTechnology

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Head/helmets.yml
@@ -51,11 +51,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Heat: 0.90
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.85
   - type: ExplosionResistance
-    damageCoefficient: 0.90
+    damageCoefficient: 0.95
 
 #ERT Amber EVA Helmet
 - type: entity

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/armor.yml
@@ -56,14 +56,14 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.45
-        Slash: 0.45
+        Blunt: 0.5
+        Slash: 0.5
         Piercing: 0.5
         Heat: 0.60
-        Radiation: 0.75
+        Radiation: 0.65
         Caustic: 0.75
   - type: ExplosionResistance
-    damageCoefficient: 0.80
+    damageCoefficient: 0.75
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
@@ -26,13 +26,6 @@
       sprite: _Sunrise/Clothing/OuterClothing/Coats/noirdet.rsi
     - type: Clothing
       sprite: _Sunrise/Clothing/OuterClothing/Coats/noirdet.rsi
-    - type: Armor
-      modifiers:
-        coefficients:
-          Blunt: 0.8
-          Slash: 0.8
-          Piercing: 0.6
-          Heat: 0.9
 
 - type: entity
   parent: ClothingOuterCoatWarden

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -50,6 +50,8 @@
     sprite: _Sunrise/Objects/Weapons/Guns/Battery/smg_laser.rsi
   - type: Item
     size: Large
+    shape:
+    - 0,0,2,1
     sprite: _Sunrise/Objects/Weapons/Guns/Battery/smg_laser.rsi
   - type: MagazineVisuals
     magState: mag
@@ -72,7 +74,7 @@
       shader: unshaded
   - type: Gun
     selectedMode: SemiAuto
-    fireRate: 3
+    fireRate: 2.75
     availableModes:
       - SemiAuto
   - type: Clothing
@@ -104,6 +106,8 @@
       shader: unshaded
   - type: Clothing
     sprite: _Sunrise/Objects/Weapons/Guns/Battery/energygun.rsi
+  - type: Item
+    size: Large
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
@@ -422,13 +426,15 @@
       shader: unshaded
   - type: Clothing
     sprite: _Sunrise/Objects/Weapons/Guns/Battery/energygun_tactical.rsi
+  - type: Item
+    size: Large
   - type: Gun
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
     selectedMode: SemiAuto
-    fireRate: 2.1
+    fireRate: 2
     availableModes:
         - SemiAuto
         - FullAuto
@@ -437,7 +443,7 @@
     startingCharge: 1500
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 15 # ~3 minute
+    autoRechargeRate: 20 # ~2 minute
     autoRechargePause: true
     autoRechargePauseTime: 60
   - type: EnergyGunFireModes

--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/security.yml
@@ -400,11 +400,10 @@
   id: ClothingShoesBootsMagCombat
   result: ClothingShoesBootsMagCombat
   category: Weapons
-  completetime: 12
+  completetime: 25
   materials:
-    Steel: 1500
+    Steel: 1200
     Plastic: 500
-    Plasma: 300
     Silver: 200
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Sunrise/Research/arsenal.yml
+++ b/Resources/Prototypes/_Sunrise/Research/arsenal.yml
@@ -37,6 +37,8 @@
   cost: 7500
   recipeUnlocks:
   - ClothingShoesBootsMagCombat
+  technologyPrerequisites:
+  - AdvancedRiotControl
 
 - type: technology
   id: Advanced Laser Manipulation


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
1. Увеличены показатели защиты на 5-10% у брони Смотрителя и ГСБ а так же их зимних вариантов
Скорректированы показатели защиты у Скафандра Смотрителя (Повышена защита против холодного оружия)
Броня SWAT снижена защита от Порез/Удар на 5%
2. Изменен Базовый хитскан на батареях 17 Ожог > 14 Ожог без изменения цены за выстрел (Хо)
3. Уменьшение размера Энерго пушки, Тактической Энерго пушки до размера ИК-60 и прочих
4. Черный Тренч Детектива теперь имеет такие же показатели как и другие Тренчи
5. Уменьшено количество брони в ДетективоМате до 1го
6. Изменены характеристики шлема Алтын теперь шлем специализируется на защите от пуль 15%, другие же показатели ниже чем стандартные шлема 5% для Брута и отсутствие защиты от лазеров.
7. Убран крафт из протолата шлема алтын за 60 стали, заменен на более дешевый аналог крафта 20 стали
Убран крафт магазинов для L6 SAW в Фабе СБ
Удешевлен крафт Боевых Магниток СБ в замен повышено время крафта
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
1. https://github.com/space-wizards/space-station-14/pull/30212
Вот ПР от которого идут идеи моих правок защиты СБ
2. Батарейные вооружения показывают хороший результат и часто могут быть замечены как выбор Сотрудников СБ заместо Огнестрельного вооружения. Изначально Свалин стрелял 7 урона но при изменения стрельбы на хитскан неожиданно стал 17, что многовато.
3. Давно стоило так сделать, Энерго Пушки не являются таким эффективным вооружением чтобы он был Огромного размера
5. Детективы и так могут взять в лодауте  тренч какой они желают, нет необходимости держать на 2х детективов Магазин Брони
7. Случайно туда попал, убрал ибо СБ не имеют Л6 как и ОБР
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
![Weapons](https://github.com/user-attachments/assets/0a395542-4492-4fce-9e5e-6809392c5033)
![Дек шкаф](https://github.com/user-attachments/assets/b5290763-e36b-41a4-a6a5-446e65abecf4)

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: Изменен урон у батарейных лазеров 17>14.
- tweak: Изменен размер Энерго Пушки\Тактической Энерго Пушки.
- tweak: Изменена защита стартовой брони и скафандра Смотрителя\ГСБ.
- tweak: Изменена защита защита SWAT Брони.
- tweak: Понижена цена создания шлема Алтын, Боевые Магнитные ботинки.
- fix: Убран Короб Л6 из Фаба СБ.
- fix: Нуарный плащ детектива имеет аналогичные характеристики другим плащам дека.