### PR TITLE
Фикс Абуза Блюспейс Коробки

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/suits.yml
@@ -7,7 +7,7 @@
   components:
   - type: Storage
     grid:
-    - 0,0,3,3
+    - 0,0,7,5
     whitelist:
       tags:
         - BluespaceBox

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Misc/box.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Misc/box.yml
@@ -10,8 +10,9 @@
     - state: icon
   - type: Item
     sprite: _Sunrise/Objects/Storage/boxes.rsi
-    size: Normal
-    shape: null
+    size: Small
+    shape:
+    - 0,0,3,2
   - type: Storage
     maxItemSize: Normal
     grid:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Фикс Абуза Блюспейс Коробки
Сделал коробки больше по размеру и сделал больше вместимости для грузового костюма что эти коробки и должен вмещать

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Часто начал замечать как люди носят в сумке по 1-4 коробки блюспейст что занимают 2на2 клетки а вмещают 5на5 но только среднего размера
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
![Снимок экрана 2025-01-18 175817](https://github.com/user-attachments/assets/551a6239-88af-486c-857d-4f0dc4435509)

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: увеличен размер блюспейс коробки.