### PR TITLE
Дебафф импланта побега

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -158,10 +158,8 @@
   - type: InstantAction
     checkCanInteract: false
     charges: 2
-    # Sunrise-Start
     renewCharges: true
     renewChargeDelay: 120
-    # Sunrise-End
     useDelay: 5
     itemIconStyle: BigAction
     priority: -20

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -158,8 +158,6 @@
   - type: InstantAction
     checkCanInteract: false
     charges: 2
-    renewCharges: true
-    renewChargeDelay: 120
     useDelay: 5
     itemIconStyle: BigAction
     priority: -20


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Убрал авто перезарядку у импланта побега
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Трейторы теперь ничего не боятся, они не боятся смерти, ибо в случае чего они смогут просто телепортироваться, из-за этого их почти не убить, убить можно только если подгадать нужное время или убить шприцемётом, что так же сложно ибо он сразу же телепортируется. Трейторы стали намного чаще играть через РДМ ибо их нельзя убить.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [ ] Я не требую помощи для завершения PR
- [ ] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [ ] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Focstor
- tweak: Имплант побега теперь без самозаряда.