### PR TITLE
Роботех: Tweak 

### DIFF
--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Science/roboticist.yml
@@ -17,7 +17,7 @@
   access:
     - Research
     - Maintenance
-    - Engineering
+  #  - Engineering
 
 - type: startingGear
   id: RoboticistGear
@@ -25,7 +25,8 @@
     outerClothing: ClothingOuterCoatRobo
     id: RoboticistPDA
     gloves: ClothingHandsGlovesRobohands
-    eyes: ClothingEyesGlassesWelding
+    head: ClothingHeadHatWelding
+    eyes: ClothingEyesHudDiagnostic
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetRobotics
     pocket1: Nanopaste


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Убраны доступы в Инж отдел Роботеху
Заменены Очки сварочные на HUD  Диагностики и Маску Сварочную на голову

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Робототехника постоянно берут ради его раундстарт Изолек, Сварочных очков и доступов в Инженерку, Фактически это Инженер что может ничего не делать по цели и работать в рнд.
Буквально самая Желанная Роль на станции по соотношению возможностей и старт эквипа.
Выдан худ чтобы Роботех видел кого надо чинить из боргов ведь это буквально его работа.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- remove: Удален доступ в инженерный отдел Робототехникам.