### PR TITLE
[BALANCE] Балансировка нескольких нередко используемых предметов.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -379,6 +379,7 @@
     - Hair
     - Snout
     hideOnToggle: true
+  - type: FlashImmunity #BALANCE PR
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -417,6 +417,10 @@
   - type: SolutionInjectOnEmbed
     transferAmount: 2
     solution: injector
+  - type: SolutionContainerManager #BALANCE PR-START
+    solutions:
+      injector:
+        maxVol: 10 #BALANCE PR-END
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Hands/gloves.yml
@@ -32,6 +32,7 @@
     sprite: _Sunrise/Clothing/Hands/Gloves/hos.rsi
   - type: Clothing
     sprite: _Sunrise/Clothing/Hands/Gloves/hos.rsi
+  - type: Insulated #BALANCE PR
 
 - type: entity
   parent: ClothingHandsButcherable

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
@@ -342,6 +342,13 @@
     sprite: _Sunrise/Clothing/OuterClothing/Coats/ussp.rsi
   - type: Clothing
     sprite: _Sunrise/Clothing/OuterClothing/Coats/ussp.rsi
+  - type: Armor #BALANCE PR-START
+    modifiers:
+        coefficients:
+          Blunt: 0.7
+          Slash: 0.7
+          Piercing: 0.4
+          Heat: 0.7 #BALANCE PR-END
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Medical/chemistry.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Medical/chemistry.yml
@@ -32,7 +32,7 @@
   - type: SolutionContainerManager
     solutions:
       injector:
-        maxVol: 8
+        maxVol: 6 #BALANCE PR
         canReact: false
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
- Изменение статистик бронешинели СССП на те же, что в данный момент характерны для остальных бронешинелей
- Добавление защиты от вспышек противогазу спецназа
- Добавление свойства изолирующих перчаток кожаным перчаткам ХОСа
- Изменение ёмкости минишприцов (Обычный минишприц с 15-и до 10-и, криостазис минишприц с 8-и до 6-и.)

## По какой причине
- Балансировка брони шинелей
- В игре имеется "Элитный противогаз СБ", у которого есть защита от вспышек, целесообразно было бы добавить её и более продвинутому противогазу.
- Кожаные перчатки ХОСа фактически то же самое, что и боевые перчатки СБ
- Слишком большая ёмкость стояла в минишприцах, 15 унций реагента с одного шприца, изменение в угоду баланса.

## Проверки

- [X] Я не требую помощи для завершения PR
- [X] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [X] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: Kendrick
- add: Добавлена защита от вспышек противогазу спецназа; добавлено свойство изолирующих перчаток кожаным перчаткам ХОСа.
- tweak: Изменены резисты бронешинели; изменены ёмкости минишприцов
