### PR TITLE
Откатываем Приколы Вигерса

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -576,10 +576,4 @@ MedicalScanner: null
 CloningPodMachineCircuitboard: null
 CloningConsoleComputerCircuitboard: null
 MedicalScannerMachineCircuitboard: null
-WeaponTurretHostile: null
-WeaponShotgunPaladin12: null
-ClothingOuterArmorSWAT: null
-ClothingHeadHelmetSwat: null
-ClothingShoesSwat: null
-Truncheon: null
 ImplantExtractor: null


### PR DESCRIPTION
## Кратное описание
Откатил прикол вигерса который как всегда никого не спросив всё удаляет.

## По какой причине
Турели используются у ИИ для защиты.
Дубинки не серьёзное изучение для удаления блять со всех карт.
Всё остальное использовалось на ивент-гридах/картах.

@VigersRay проси маперов чтоб удаляли эту хуйню а не таким образом обрезай всё.
Так же понижай ТК грёбаным агентам с 40 тк до 20 раз уж убрали доп цели. Такие оружейки существуют из-за твоих Имба трейторов на 40 тк.

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

