### PR TITLE
[Fix] Большие Двигатели (Коллизия и HP)

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Structures/Shuttles/thrusters.yml
@@ -5,7 +5,7 @@
   components:
   - type: Anchorable
     flags:
-    - Unanchorable
+    - Anchorable
   - type: Sprite
     sprite: _Sunrise/Structures/Shuttles/big_thruster.rsi
     layers:
@@ -27,7 +27,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.9,-0.9,0.9,0.9"
+          bounds: "-0.35,-0.35,1.30,1.30"
         density: 60
         mask:
         - MachineMask
@@ -39,6 +39,27 @@
     damage:
       types:
         Heat: 80
+  - type: Machine
+    board: ThrusterMachineCircuitboard
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1500
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 1450
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalBreak
+        - !type:ChangeConstructionNodeBehavior
+          node: machineFrame
 
 - type: entity
   id: BigRedThruster
@@ -69,7 +90,7 @@
   components:
   - type: Anchorable
     flags:
-    - Unanchorable
+    - Anchorable
   - type: Sprite
     sprite: _Sunrise/Structures/Shuttles/huge_thruster.rsi
     layers:
@@ -91,7 +112,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-1.35,-1.35,1.35,1.35"
+          bounds: "-0.20,-0.25,2.20,2.20"
         density: 60
         mask:
         - MachineMask
@@ -103,6 +124,27 @@
     damage:
       types:
         Heat: 160
+  - type: Machine
+    board: ThrusterMachineCircuitboard
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 4500
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 4450
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalBreak
+        - !type:ChangeConstructionNodeBehavior
+          node: machineFrame
 
 - type: entity
   id: HugeRedThruster
@@ -119,7 +161,7 @@
       map: ["enum.ThrusterVisualLayers.ThrustOn"]
       shader: unshaded
       visible: false
-      offset: 1,0.95
+      offset: 1, 0.95
     - state: red_thrust_burn_unshaded
       map: ["enum.ThrusterVisualLayers.ThrustingUnshaded"]
       shader: unshaded


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Большие двигатели стали прочнее примерно в 5 - 10 раз (Самое то для Ивентовых шаттлов и невосполняемой сложной **Большой** структуры)
Фикс коллизии двигателей Больших
Двигатели больше нельзя открутить но можно прикрутить (Убран самый простой и легкий Гриф шаттла)
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
![image](https://github.com/user-attachments/assets/723c5631-d296-4827-922e-090bf1eb7c16)
![image](https://github.com/user-attachments/assets/0daa42ae-217d-4599-bf60-e412553d201e)

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- tweak: Изменена прочность Больших Двигателей ~X5-10.
- fix: Исправлена коллизия Больших Двигателей.