### PR TITLE
[BALANCE] Ребаланс галош

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -113,12 +113,15 @@
     sprite: Clothing/Shoes/Specific/galoshes.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Specific/galoshes.rsi
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: NoSlip
   - type: SlowedOverSlippery
-    slowdownModifier: 0.7
+    slowdownModifier: 0.75
   - type: SpeedModifierContactCapClothing
-    maxContactSprintSlowdown: 0.7
-    maxContactWalkSlowdown: 0.7
+    maxContactSprintSlowdown: 0.75
+    maxContactWalkSlowdown: 0.75
 
 - type: entity
   parent: [ClothingShoesBaseButcherable, BaseMajorContraband]


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
- Изменение характеристик галош (Пассивное замедление 0% -> 10%, Замедление на лужах 30% -> 25%)

## По какой причине
При нынешней ситуации галоши используют как боевое снаряжение, но это не основная проблема, главная беда кроется в том, что из-за галош для агентов к примеру пропадал смысл покупать ноуслипы/кроваво-красные магнитки, при одобрении этого ПРа смысл появится.

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

:cl: Kendrick
- tweak: Изменено характеристики галош.
