### PR TITLE
Баланс ЕМАГа

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -120,5 +120,3 @@
     ToyFigurinePassenger: 1
     ToyFigurineGreytider: 1
   # DO NOT ADD MORE, USE UNIFORM DYING
-  emaggedInventory:
-    ClothingHeadHelmetSwatSyndicate: 1 # Sunrise Edit

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -34,3 +34,5 @@
     ToyFigurineSecurity: 1
     ToyFigurineWarden: 1
     ToyFigurineHeadOfSecurity: 1
+  emaggedInventory:
+    ClothingHeadHelmetSwatSyndicate: 1 # Sunrise Edit

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
@@ -9,4 +9,4 @@
   contrabandInventory:
     PowerCellSmall: 2
   emaggedInventory:
-    StimpackMini: 2 # Sunrise Edit
+    StimpackMini: 1 # Sunrise Edit


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Два мини стимпака из взламываемого НаноМеда стали одним.
Взламываемый ОдеждоМат перестал выдавать шлем спецназа, вместо этого его стал выдавать ОхранШкаф
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Два министимпака равны одному большому по количеству реагентов, не дело. 
ОдеждоМат слишком легко взломать чтобы получить шлем спецназа.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**

:cl: banumbas
- tweak: Два мини стимпака из взламываемого НаноМеда стали одним.
- tweak: Взламываемый ОдеждоМат перестал выдавать шлем спецназа, вместо этого его стал выдавать ОхранШкаф