### PR TITLE
Изменение характеристик глефы-крушителя и крушителя

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -135,8 +135,8 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 10
-        Slash: 5
+        Blunt: 20 #sunrise-start
+        Slash: 10 #sunrise-end
     soundHit:
       collection: MetalThud
   - type: Wieldable
@@ -173,7 +173,7 @@
     tags:
     - Knife
 
-# Like a crusher... but better
+# Like a crusher... but better healing
 - type: entity
   parent: [ WeaponCrusher, BaseSecurityCargoContraband]
   id: WeaponCrusherGlaive
@@ -189,6 +189,10 @@
       groups:
         Brute: -21
   - type: MeleeWeapon
+    damage: #sunrise-start
+      types:
+        Blunt: 6.5
+        Slash: 2.5 #sunrise-end
   - type: Tag
     tags:
       - Pickaxe


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
- Урон крушителя (Секира) увеличен до 20 blunt и 10 slash по умолчанию (60-65 урона по голому телу под меткой)
- Урон глефы-крушителя уменьшен до 6.5 blunt и 2.5 slash по умолчанию (30-40 урона по голому телу под меткой)

## По какой причине
- Крушитель и глефа-крушитель разнятся в показателях лечения, которое получает пешка, ударив по телу под меткой. Глефа лечит в раза 4 больше, чем крушитель. Теперь утилизатором будет целесообразно использовать и крушитель и глефу-крушитель из-за их разницы в уроне.

## Проверки

- [X] Я не требую помощи для завершения PR
- [X] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [X] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: Kendrick
- tweak: Изменены показатели урона на Крушителе и Глефе-Крушителе.
