### PR TITLE
Баланс космического ниндзя

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -247,6 +247,12 @@
         whitelist:
           components:
           - Stamina
+        stunCharge: 120 #sunrise-start
+      - type: StunProvider
+        noPowerPopup: ninja-no-power
+        whitelist:
+          components:
+          - Stamina #sunrise-end
       - type: EmagProvider
         whitelist:
           components:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -163,12 +163,12 @@
       minVisibility: 0 # Sunrise-Edit
       lastVisibility: 0 # Sunrise-Edit
   - type: PowerCellDraw
-    drawRate: 1.8 # 200 seconds on the default cell
+    drawRate: 20 # Sunrise-edit
   - type: ToggleCellDraw
   # throwing star ability
   - type: ItemCreator
     action: ActionCreateThrowingStar
-    charge: 14.4
+    charge: 90 #Sunrise-edit
     spawnedPrototype: ThrowingStarNinja
     noPowerPopup: ninja-no-power
   # core ninja suit stuff
@@ -186,7 +186,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellSmall
+        startingItem: PowerCellMicroreactor #sunrise-edit
         disableEject: true
         whitelist:
           tags:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -186,7 +186,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMicroreactor #sunrise-edit
+        startingItem: PowerCellSmall
         disableEject: true
         whitelist:
           tags:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
- Изменена батарея в костюме космического ниндзи на микрореакторную, которую нельзя вынуть.
- Повышена энергозатрата невидимости (3 в тик, при учёте работа микрореакторки)
- Повышена энергозатрата на создание сюрикена - 10% энергии
- Повышена затрата на стан перчаток - 15% энергии

## По какой причине
- Ниндзя не будет зависеть от развитости РНД, а также будет требовать от игрока на нём дополнительной аккуратности, ведь теперь, он не сможет как раньше бесконечно бегать в невидимости и сверху ещё накидывать стан без последствий для себя.

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
:cl: Kendrick
- tweak: Батарею в костюме космического ниндзя больше нельзя заменить.
- tweak: Повышена энергозатрата невидимости.
- tweak: Повышена энергозатрата на создание сюрикена.
- tweak: Повышена затрата на оглушение перчаток.
