### PR TITLE
Баланс Рейд Брони

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -124,13 +124,13 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.1 #sunrise-Edit
-        Slash: 0.3 #sunrise-Edit
-        Piercing: 0.2 #sunrise-Edit
-        Heat: 0.3 #sunrise-Edit
-        Caustic: 0.2
+        Blunt: 0.75 #sunrise-Edit
+        Slash: 0.8 #sunrise-Edit
+        Piercing: 0.75 #sunrise-Edit
+        Heat: 0.8 #sunrise-Edit
+        Caustic: 0.55
   - type: ExplosionResistance
-    damageCoefficient: 0.35
+    damageCoefficient: 0.65
   - type: PressureProtection  #Sunrise-start
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -124,10 +124,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75 #sunrise-Edit
-        Slash: 0.8 #sunrise-Edit
-        Piercing: 0.75 #sunrise-Edit
-        Heat: 0.8 #sunrise-Edit
+        Blunt: 0.75 # Sunrise-Edit
+        Slash: 0.8 # Sunrise-Edit
+        Piercing: 0.45 # Sunrise-Edit
+        Heat: 0.9 # Sunrise-Edit
         Caustic: 0.55
   - type: ExplosionResistance
     damageCoefficient: 0.65
@@ -138,8 +138,8 @@
     heatingCoefficient: 0.2
     coolingCoefficient: 0.5 #Sunrise-end
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.65
+    walkModifier: 0.85
+    sprintModifier: 0.85
   #Shoulder mounted flashlight
   - type: ToggleableLightVisuals
     spriteLayer: light

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -124,11 +124,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4 #sunrise-Edit
-        Slash: 0.4 #sunrise-Edit
-        Piercing: 0.4 #sunrise-Edit
-        Heat: 0.4 #sunrise-Edit
-        Caustic: 0.5
+        Blunt: 0.1 #sunrise-Edit
+        Slash: 0.3 #sunrise-Edit
+        Piercing: 0.2 #sunrise-Edit
+        Heat: 0.3 #sunrise-Edit
+        Caustic: 0.2
   - type: ExplosionResistance
     damageCoefficient: 0.35
   - type: PressureProtection  #Sunrise-start
@@ -138,8 +138,8 @@
     heatingCoefficient: 0.2
     coolingCoefficient: 0.5 #Sunrise-end
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.90
+    walkModifier: 0.75
+    sprintModifier: 0.65
   #Shoulder mounted flashlight
   - type: ToggleableLightVisuals
     spriteLayer: light


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Изменить мету

## По какой причине
Чел с рейд броней буквально может пережить обоймы патронов, надо фиксить.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**


:cl: RaMbUt878
- fix: Синдикат начал экономить на производстве брони для рейдов. Защита снижена.

