### PR TITLE
Добавление мешка с землей в биогенератор

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1431,6 +1431,7 @@
     - BioGenLeft4Zed
     - BioGenEZNutrient
     - BioGenRobustHarvest
+    - BioGenHandheldSoil # Sunrise-Edit
 
 - type: entity
   parent: BaseLathe

--- a/Resources/Prototypes/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/Recipes/Lathes/biogen.yml
@@ -228,5 +228,12 @@
   materials:
     Biomass: 18
 
-
-
+# Sunrise-Start
+- type: latheRecipe
+  id: BioGenHandheldSoil
+  result: HandheldSoil
+  category: Materials
+  completetime: 3
+  materials:
+    Biomass: 149
+# Sunrise-End


### PR DESCRIPTION
## Краткое описание
Добавить мешок с землей в биогенератор

## По какой причине
Карго редко одобряет покупку большого количества мешков с землей. Крафт мешка земли в биогенераторе будет довольно дорогим (149 биомассы), но хотя бы даст игрокам возможность добыть его самостоятельно.
## Медиа(Видео/Скриншоты)
![2025-02-09_17h10_47](https://github.com/user-attachments/assets/dea217c9-5887-4429-95f1-352bad0e9749)


**Changelog**
:cl: temm1ie
- add: Теперь мешок земли можно создать в биогенераторе за 149 биомассы.

