### PR TITLE
Небольшие правки в ИСН

### DIFF
--- a/Resources/Locale/en-US/_strings/_sunrise/job/job-names.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/job/job-names.ftl
@@ -35,7 +35,7 @@ job-name-usspsoldier = Солдат СССП
 job-name-usspofficer = Офицер СССП
 job-name-usspcaptain = Капитан СССП
 # NTR
-job-name-ntrguard = Оператор ИСН
+job-name-ntrguard = офицер ИСН
 job-name-ntrleader = Командир ИСН
 # Перевод трекеров времени
 JobCentCommOfficial = представитель Центком

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Back/backpacks.yml
@@ -86,6 +86,6 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,7,3
+    - 0,0,6,4
   - type: ExplosionResistance
-    damageCoefficient: 0.1
+    damageCoefficient: 0.80

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Back/backpacks.yml
@@ -86,4 +86,6 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,7,4
+    - 0,0,7,3
+  - type: ExplosionResistance
+    damageCoefficient: 0.1

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
@@ -385,13 +385,13 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.45
-        Heat: 0.5
-        Caustic: 0.6
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.5
+        Heat: 0.7
+        Caustic: 0.7
   - type: ExplosionResistance
-    damageCoefficient: 0.60
+    damageCoefficient: 0.75
   - type: Item
     size: Huge
 
@@ -412,17 +412,17 @@
     sprite: _Sunrise/Clothing/OuterClothing/Coats/ntrg_armor.rsi
   - type: ClothingSpeedModifier
     walkModifier: 1
-    sprintModifier: 0.9
+    sprintModifier: 0.85
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.45
-        Heat: 0.5
-        Caustic: 0.6
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.55
+        Heat: 0.7
+        Caustic: 0.7
   - type: ExplosionResistance
-    damageCoefficient: 0.60
+    damageCoefficient: 0.75
   - type: Item
     size: Huge
   - type: Storage

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/coats.yml
@@ -428,4 +428,4 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,5,1
+    - 0,0,3,1

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -53,6 +53,8 @@
     sprite: _Sunrise/Clothing/OuterClothing/Hardsuits/ntrguard_spacesuit.rsi
   - type: Item
     size: Huge
+    shape:
+    - 0,0,4,4 #5X5, can fit in a duffel bag but nothing smaller.
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitNTRG
 

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -223,7 +223,7 @@
   name: pulse revolver
   parent: BaseWeaponBatterySmall
   id: WeaponEnergyGunPulseRevolver
-  description: This is an expensive modern Pulse gun. This gun has several unique firemodes. 
+  description: This is an expensive modern Pulse gun. This gun has several unique firemodes.
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Weapons/Guns/Battery/pulse_revolver.rsi
@@ -239,6 +239,7 @@
   - type: Clothing
     sprite: _Sunrise/Objects/Weapons/Guns/Battery/pulse_revolver.rsi
   - type: Gun
+    fireRate: 2.75
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
     soundEmpty:
@@ -248,13 +249,13 @@
     startingCharge: 720
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 120
+    autoRechargeRate: 145
     autoRechargePause: true
-    autoRechargePauseTime: 6
+    autoRechargePauseTime: 4
   - type: EnergyGunFireModes
     fireModes:
     - hitscanProto: BulletDisabler
-      fireCost: 60
+      fireCost: 90
       name: energy-gun-disable
       state: disabler
       shotType: Hitscan
@@ -278,7 +279,7 @@
     tags:
     - Sidearm
   - type: StaticPrice
-    price: 17500
+    price: 12500
 
 - type: entity
   name: miniature energy gun

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/CentralCommand/ntr_guard.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/CentralCommand/ntr_guard.yml
@@ -64,7 +64,7 @@
     pocket1: WeaponEnergyGunPulseRevolver
     pocket2: HandheldCriminalRecordsMonitorUnpowered
   inhand:
-  - WeaponDisablerSMG
+  - WeaponEnergyGunTactical
   storage:
     back:
     - ClothingOuterHardsuitNTRG


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Рядовой боец ИСН теперь не Оператор а Офицер ИСН
ИСН теперь имеет тактический лазер вместо Станер ПП (Тактический лазер имеет долгую зарядку но является Энерго Аналогом Станера ПП)
Изменены показатели брони отряда
Немного уменьшен размер Сумки-Рюкзака отряда
Сумке добавлена защита от взрыва вещей содержимого сумки 10%>20%
![image](https://github.com/user-attachments/assets/3aec6f64-f739-4e96-a696-ed7acff47205)
Изменен размер скафа ИСН.
Без вещмешка или кражи сумки ИСН никто не сможет скрытно носить скафандр.
Базово Скафандр сильно ограничивает ИСН в размере инвентаря
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
https://github.com/space-sunrise/space-station-14/issues/1341 - Переименование Оператора в Офицера 

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->

:cl: KaiserMaus
- tweak: Ввиду массовой отправки отрядов ИСН, НТ удешевила защиту отряда.