### PR TITLE
Баланс рейдерки и изменение цены УЗИ

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -124,10 +124,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4 #sunrise-Edit
-        Slash: 0.4 #sunrise-Edit
+        Blunt: 0.6 #sunrise-Edit
+        Slash: 0.6 #sunrise-Edit
         Piercing: 0.4 #sunrise-Edit
-        Heat: 0.4 #sunrise-Edit
+        Heat: 0.6 #sunrise-Edit
         Caustic: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.35
@@ -138,8 +138,8 @@
     heatingCoefficient: 0.2
     coolingCoefficient: 0.5 #Sunrise-end
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.90
+    walkModifier: 0.9
+    sprintModifier: 0.9
   #Shoulder mounted flashlight
   - type: ToggleableLightVisuals
     spriteLayer: light

--- a/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
@@ -1325,9 +1325,9 @@
   productEntity: UplinkSubMachineGunUzi
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 6
+    Telecrystal: 8
   cost:
-    Telecrystal: 12
+    Telecrystal: 16
   categories:
   - UplinkWeaponry
   conditions:


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Повысил цену УЗИ с 12 тк до 16 в угоду баланса
Повысил резисты рейд костюма синдиката
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Баланс цены на УЗИ, повышение резистов рейд.костюма в угоду баланса. Сейчас просто выгоднее купить тактический жилет синдиката
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
:cl: freychik
- tweak: Повышена цена на УЗИ
- tweak: Повышены резисты рейдерского костюма синдиката
