### PR TITLE
Откат обновлений рейд.костюма

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1694,6 +1694,13 @@
     Telecrystal: 3
   categories:
   - UplinkWearables
+- #Sunrise-start
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
+  #Sunrise-end
 
 - type: listing
   id: UplinkClothingShoesBootsMagSyndie

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -416,14 +416,6 @@
     sprite: Clothing/Head/Helmets/syndie-raid.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/syndie-raid.rsi
-  - type: TemperatureProtection #sunrise-start
-    heatingCoefficient: 0.01
-    coolingCoefficient: 0.2
-  - type: FireProtection
-    reduction: 0.2
-  - type: PressureProtection
-    highPressureMultiplier: 0.25
-    lowPressureMultiplier: 1000 #sunrise-end
   - type: Armor
     modifiers: #There's gotta be SOME reason to use this over other helmets.
       coefficients:
@@ -431,6 +423,7 @@
         Slash: 0.85
         Piercing: 0.85
         Heat: 0.85
+
 
 #Bone Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -117,7 +117,7 @@
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
-  description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.
+  description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect it's wearer from space.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi
@@ -131,19 +131,13 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6 # Sunrise-Edit
-        Slash: 0.6 # Sunrise-Edit
-        Piercing: 0.4 # Sunrise-Edit
-        Heat: 0.6 # Sunrise-Edit
+        Blunt: 0.35
+        Slash: 0.35
+        Piercing: 0.35
+        Heat: 0.35
         Caustic: 0.5
   - type: ExplosionResistance
-    damageCoefficient: 0.65
-  - type: PressureProtection  #Sunrise-start
-    highPressureMultiplier: 0.6
-    lowPressureMultiplier: 1000
-  - type: TemperatureProtection
-    heatingCoefficient: 0.2
-    coolingCoefficient: 0.5 #Sunrise-end
+    damageCoefficient: 0.35
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -131,8 +131,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.35
-        Slash: 0.35
+        Blunt: 0.4
+        Slash: 0.4
         Piercing: 0.35
         Heat: 0.35
         Caustic: 0.5

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Clothing/Biocode/hardsuits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Clothing/Biocode/hardsuits.yml
@@ -62,3 +62,16 @@
       path: "/Audio/Effects/beep1.ogg"
       params:
         volume: 15
+
+- type: entity
+  parent: ClothingOuterArmorRaid
+  id: ClothingOuterArmorRaidBiocode
+  suffix: BIOCODE
+  components:
+  - type: FactionClothingBlocker
+    factions:
+    - Syndicate
+    beepSound:
+      path: "/Audio/Effects/beep1.ogg"
+      params:
+        volume: 15


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Откатил обновления Санрайза с рейдерским костюмом и убрал такт.жилет у ядерных оперативников
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Баланс как и сказал Кайсер, теперь рейд.костюм не защищает от разгерметизации совсем. А тактический жилет убран тоже ради баланса. Пусть покупают рейдерский костюм
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: freychik
- tweak: Рейдерский костюм теперь не защищает от разгерметизацией, но получил защиту как раньше
- tweak: Ядерные оперативники теперь не могут купить тактический жилет