### PR TITLE
Откат голода и жажды

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     /// <remarks>Any time this is modified, <see cref="HungerSystem.SetAuthoritativeHungerValue"/> should be called.</remarks>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.15f; // Sunrise-Edit
+    public float BaseDecayRate = 0.01666666666f; 
 
     /// <summary>
     /// The actual amount at which <see cref="LastAuthoritativeHungerValue"/> decays.

--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class ThirstComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("baseDecayRate")]
     [AutoNetworkedField]
-    public float BaseDecayRate = 0.3f; // Sunrise-Edit
+    public float BaseDecayRate = 0.1f; 
 
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]


### PR DESCRIPTION
## Кратное описание
Откат обновления голода и жажды

## По какой причине
Пешки слишком быстро голодают и получаю жажду. По жалобам игроков, примерно каждые 10 минут нужно есть


**Changelog**
fix: Био-инженеры Nanotrasen исправили желудки персонала. Теперь они не будут голодать так быстро

