### PR TITLE
Визуализация указывания стрелочкой в чате

### DIFF
--- a/Content.Client/Options/UI/Tabs/ExtraTab.xaml
+++ b/Content.Client/Options/UI/Tabs/ExtraTab.xaml
@@ -33,6 +33,7 @@
                 <!-- Graphics -->
                 <Label Text="{Loc 'ui-options-sunrise-general-graphics'}" StyleClasses="LabelKeyText"/>
                 <CheckBox Name="ChatIconsEnableCheckBox" Text="{Loc 'ui-options-chat-icons-enable'}" />
+                <CheckBox Name="ChatPointingVisualsEnableCheckBox" Text="{Loc 'ui-options-chat-pointing-visuals-enable'}" />
 
             </BoxContainer>
         </ScrollContainer>

--- a/Content.Client/Options/UI/Tabs/ExtraTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/ExtraTab.xaml.cs
@@ -93,6 +93,7 @@ public sealed partial class ExtraTab : Control
         Control.AddOptionCheckBox(SunriseCCVars.DamageOverlayStructures, DamageOverlayStructuresCheckBox);
 
         Control.AddOptionCheckBox(SunriseCCVars.ChatIconsEnable, ChatIconsEnableCheckBox);
+        Control.AddOptionCheckBox(SunriseCCVars.ChatPointingVisuals, ChatPointingVisualsEnableCheckBox);
 
         Control.Initialize();
     }

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -77,6 +77,7 @@ namespace Content.Client.Popups
                 ("count", existingLabel.Repeats));
         }
 
+        // Sunrise edit - добавил EntityUid? origin = null, сделал bool recordReplay = true по умолчанию true
         private void PopupMessage(string? message, PopupType type, EntityCoordinates coordinates, EntityUid? entity, EntityUid? origin = null, bool recordReplay = true)
         {
             if (message == null)
@@ -254,15 +255,19 @@ namespace Content.Client.Popups
 
         private void OnPopupCoordinatesEvent(PopupCoordinatesEvent ev)
         {
+            // Sunrise edit start - добавил GetEntity(ev.Origin)
             PopupMessage(ev.Message, ev.Type, GetCoordinates(ev.Coordinates), null, GetEntity(ev.Origin), false);
+            // Sunrise edit end
         }
 
         private void OnPopupEntityEvent(PopupEntityEvent ev)
         {
             var entity = GetEntity(ev.Uid);
 
+            // Sunrise edit start - добавил GetEntity(ev.Origin)
             if (TryComp(entity, out TransformComponent? transform))
                 PopupMessage(ev.Message, ev.Type, transform.Coordinates, entity, GetEntity(ev.Origin), false);
+            // Sunrise edit end
         }
 
         private void OnRoundRestart(RoundRestartCleanupEvent ev)

--- a/Content.Client/_Sunrise/ChatIcons/PointIconsSystem.cs
+++ b/Content.Client/_Sunrise/ChatIcons/PointIconsSystem.cs
@@ -1,0 +1,73 @@
+﻿using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.Chat;
+using Content.Shared.Examine;
+using Content.Shared.Popups;
+using Robust.Client.Player;
+using Robust.Client.UserInterface;
+
+namespace Content.Client._Sunrise.ChatIcons;
+
+public sealed class PointIconsSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
+
+    private const string FontSize = "10";
+
+    private const string CautionColor = "c62828";
+    private const string BaseColor = "aeabc4";
+
+    private readonly Dictionary<PopupType, string> _fontSizeDict = new ()
+    {
+        { PopupType.Medium, "12" },
+        { PopupType.MediumCaution, "12" },
+        { PopupType.Large, "15" },
+        { PopupType.LargeCaution, "15" }
+    };
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MetaDataComponent, EntityPopupedEvent>(OnPopup);
+    }
+
+    private void OnPopup(Entity<MetaDataComponent> ent, ref EntityPopupedEvent args)
+    {
+        if (_playerManager.LocalEntity == null)
+            return;
+
+        if (!_examine.InRangeUnOccluded(_playerManager.LocalEntity.Value, Transform(ent).Coordinates, 10))
+            return;
+
+        var fontsize = _fontSizeDict.GetValueOrDefault(args.Type, FontSize);
+        var fontcolor = args.Type is PopupType.LargeCaution or PopupType.MediumCaution or PopupType.SmallCaution
+            ? CautionColor
+            : BaseColor;
+
+        var tag = Loc.GetString("ent-texture-tag-short", ("id", ent.Owner.Id));
+        var wrappedMessage = $"[font size={fontsize}][color=#{fontcolor}]{args.Message + tag}[/color][/font]";
+
+        var chatMsg = new ChatMessage(ChatChannel.Emotes,
+            args.Message,
+            wrappedMessage,
+            NetEntity.Invalid,
+            null);
+
+        _uiManager.GetUIController<ChatUIController>().ProcessChatMessage(chatMsg);
+    }
+}
+
+public sealed class EntityPopupedEvent : EntityEventArgs
+{
+    public readonly string Message;
+    public readonly PopupType Type;
+
+    public EntityPopupedEvent(string message, PopupType type)
+    {
+        Message = message;
+        Type = type;
+    }
+}

--- a/Content.Client/_Sunrise/UserInterface/Controls/SunriseSpriteView.cs
+++ b/Content.Client/_Sunrise/UserInterface/Controls/SunriseSpriteView.cs
@@ -1,0 +1,296 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Sunrise.UserInterface.Controls;
+
+[Virtual]
+public class SunriseStaticSpriteView : Control
+{
+    protected SpriteSystem? SpriteSystem;
+    private SharedTransformSystem? _transform;
+    protected readonly IEntityManager EntMan;
+
+    private SpriteComponent? _cachedSprite;
+    private readonly Angle _cachedWorldRotation = Angle.Zero;
+
+    [ViewVariables]
+    public SpriteComponent? Sprite => Entity?.Comp1;
+
+    [ViewVariables]
+    public Entity<SpriteComponent, TransformComponent>? Entity { get; private set; }
+
+    [ViewVariables]
+    public NetEntity? NetEnt { get; private set; }
+
+    /// <summary>
+    /// This field configures automatic scaling of the sprite. This automatic scaling is done before
+    /// applying the explicitly set scale <see cref="SunriseStaticSpriteView.Scale"/>.
+    /// </summary>
+    public StretchMode Stretch  { get; set; } = StretchMode.Fit;
+
+    public enum StretchMode
+    {
+        /// <summary>
+        /// Don't automatically scale the sprite. The sprite can still be scaled via <see cref="SunriseStaticSpriteView.Scale"/>
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Scales the sprite down so that it fits within the control. Does not scale the sprite up. Keeps the same
+        /// aspect ratio. This automatic scaling is done before applying <see cref="SunriseStaticSpriteView.Scale"/>.
+        /// </summary>
+        Fit,
+
+        /// <summary>
+        /// Scale the sprite up or down so that it fills the whole control. Keeps the same aspect ratio. This
+        /// automatic scaling is done before applying <see cref="SunriseStaticSpriteView.Scale"/>.
+        /// </summary>
+        Fill
+    }
+
+    /// <summary>
+    /// Overrides the direction used to render the sprite.
+    /// </summary>
+    /// <remarks>
+    /// If null, the world space orientation of the entity will be used. Otherwise the specified direction will be
+    /// used.
+    /// </remarks>
+    public Direction? OverrideDirection { get; set; }
+
+    #region Transform
+
+    private Vector2 _scale = Vector2.One;
+    private Angle _eyeRotation = Angle.Zero;
+    private Angle? _worldRotation = Angle.Zero;
+
+    public Angle EyeRotation
+    {
+        get => _eyeRotation;
+        set
+        {
+            _eyeRotation = value;
+            InvalidateMeasure();
+        }
+    }
+
+    /// <summary>
+    /// Used to override the entity's world rotation. Note that the desired size of the control will not
+    /// automatically get updated as the entity's world rotation changes.
+    /// </summary>
+    public Angle? WorldRotation
+    {
+        get => _worldRotation;
+        set
+        {
+            _worldRotation = value;
+            InvalidateMeasure();
+        }
+    }
+
+    /// <summary>
+    /// Scale to apply when rendering the sprite. This is separate from the sprite's scale.
+    /// </summary>
+    public Vector2 Scale
+    {
+        get => _scale;
+        set
+        {
+            _scale = value;
+            InvalidateMeasure();
+        }
+    }
+
+    /// <summary>
+    /// Cached desired size. Differs from <see cref="Control.DesiredSize"/> as it it is not clamped by the
+    /// minimum/maximum size options.
+    /// </summary>
+    private Vector2 _spriteSize;
+
+    /// <summary>
+    /// Determines whether or not the sprite's offset be applied to the control.
+    /// </summary>
+    public bool SpriteOffset { get; set; }
+
+    #endregion
+
+    public SunriseStaticSpriteView()
+    {
+        IoCManager.Resolve(ref EntMan);
+        RectClipContent = true;
+    }
+
+    public SunriseStaticSpriteView(IEntityManager entMan)
+    {
+        EntMan = entMan;
+        RectClipContent = true;
+    }
+
+    public SunriseStaticSpriteView(EntityUid? uid, IEntityManager entMan)
+    {
+        EntMan = entMan;
+        RectClipContent = true;
+        SetEntity(uid);
+    }
+
+    public SunriseStaticSpriteView(NetEntity uid, IEntityManager entMan)
+    {
+        EntMan = entMan;
+        RectClipContent = true;
+        SetEntity(uid);
+    }
+
+    public void SetEntity(NetEntity netEnt)
+    {
+        if (netEnt == NetEnt)
+            return;
+
+        if (EntMan.TryGetEntity(netEnt, out var uid))
+        {
+            SetEntity(uid);
+        }
+        else
+        {
+            // Подписаться на событие появления сущности
+            Entity = null;
+            NetEnt = netEnt;
+        }
+    }
+
+    public void SetEntity(EntityUid? uid)
+    {
+        if (Entity?.Owner == uid)
+            return;
+
+        if (!EntMan.TryGetComponent(uid, out SpriteComponent? sprite)
+            || !EntMan.TryGetComponent(uid, out TransformComponent? xform))
+        {
+            Entity = null;
+            NetEnt = null;
+            return;
+        }
+
+        // Создаем глубокую копию спрайта
+        _cachedSprite = new SpriteComponent();
+        _cachedSprite.CopyFrom(sprite); // Используем встроенный метод копирования
+
+        Entity = new(uid.Value, sprite, xform);
+        NetEnt = EntMan.GetNetEntity(uid);
+    }
+    protected override Vector2 MeasureOverride(Vector2 availableSize)
+    {
+        // TODO Make this get called when sprite bounds/properties update?
+        UpdateSize();
+        return _spriteSize;
+    }
+
+    private void UpdateSize()
+    {
+        if (!ResolveEntity(out _, out var sprite, out _))
+            return;
+
+        var spriteBox = sprite.CalculateRotatedBoundingBox(default,  _worldRotation ?? Angle.Zero, _eyeRotation)
+            .CalcBoundingBox();
+
+        if (!SpriteOffset)
+        {
+            // re-center the box.
+            spriteBox = spriteBox.Translated(-spriteBox.Center);
+        }
+
+        // Scale the box (including any offset);
+        var scale = _scale * EyeManager.PixelsPerMeter;
+        var bl = spriteBox.BottomLeft * scale;
+        var tr = spriteBox.TopRight * scale;
+
+        // This view will be centered on (0,0). If the sprite was shifted by (1,2) the actual size of the control
+        // would need to be at least (2,4).
+        tr = Vector2.Max(tr, Vector2.Zero);
+        bl = Vector2.Min(bl, Vector2.Zero);
+        tr = Vector2.Max(tr, -bl);
+        bl = Vector2.Min(bl, -tr);
+        var box = new Box2(bl, tr);
+
+        DebugTools.Assert(box.Contains(Vector2.Zero));
+        DebugTools.Assert(box.TopLeft.EqualsApprox(-box.BottomRight));
+
+        if (_worldRotation != null
+            && _eyeRotation == Angle.Zero) // TODO This shouldn't need to be here, but I just give up at this point I am going fucking insane looking at rotating blobs of pixels. I doubt anyone will ever even use rotated sprite views.?
+        {
+            _spriteSize = box.Size;
+            return;
+        }
+
+        // Size does not auto-update with world rotation. So if it is not fixed by _worldRotation we will just take
+        // the maximum possible size.
+        var size = box.Size;
+        var longestSide = MathF.Max(size.X, size.Y);
+        var longestRotatedSide = Math.Max(longestSide, (size.X + size.Y) / MathF.Sqrt(2));
+        _spriteSize = new Vector2(longestRotatedSide, longestRotatedSide);
+    }
+
+    protected override void Draw(IRenderHandle renderHandle)
+    {
+        if (!ResolveEntity(out var uid, out _, out var xform) || _cachedSprite == null)
+            return;
+
+        SpriteSystem ??= EntMan.System<SpriteSystem>();
+        _transform ??= EntMan.System<TransformSystem>();
+
+        var stretchVec = Stretch switch
+        {
+            StretchMode.Fit => Vector2.Min(Size / _spriteSize, Vector2.One),
+            StretchMode.Fill => Size / _spriteSize,
+            _ => Vector2.One,
+        };
+        var stretch = MathF.Min(stretchVec.X, stretchVec.Y);
+
+        var offset = SpriteOffset
+            ? Vector2.Zero
+            : - (-_eyeRotation).RotateVec(_cachedSprite.Offset * _scale) * new Vector2(1, -1) * EyeManager.PixelsPerMeter;
+
+        var position = PixelSize / 2 + offset * stretch * UIScale;
+        var scale = Scale * UIScale * stretch;
+
+        var world = renderHandle.DrawingHandleWorld;
+        var oldModulate = world.Modulate;
+        world.Modulate *= Modulate * ActualModulateSelf;
+
+        renderHandle.DrawEntity(
+            uid,
+            position,
+            scale,
+            _cachedWorldRotation, // Используем сохраненный поворот
+            _eyeRotation,
+            OverrideDirection,
+            _cachedSprite, // Кэшированный спрайт
+            xform
+        );
+
+        world.Modulate = oldModulate;
+    }
+
+    private bool ResolveEntity(
+        out EntityUid uid,
+        [NotNullWhen(true)] out SpriteComponent? sprite,
+        [NotNullWhen(true)] out TransformComponent? xform)
+    {
+        sprite = _cachedSprite; // Возвращаем кэшированный спрайт
+        xform = null; // Не используем текущий transform
+
+        if (NetEnt != null && Entity == null && EntMan.TryGetEntity(NetEnt, out var ent))
+            SetEntity(ent);
+
+        if (Entity != null)
+        {
+            uid = Entity.Value.Owner;
+            return !EntMan.Deleted(uid);
+        }
+
+        uid = default;
+        return false;
+    }
+}

--- a/Content.Client/_Sunrise/UserInterface/RichText/BaseTextureTag.cs
+++ b/Content.Client/_Sunrise/UserInterface/RichText/BaseTextureTag.cs
@@ -65,7 +65,7 @@ public abstract class BaseTextureTag : IMarkupTag
             return false;
 
         spriteView.SetEntity(entityUid);
-        //spriteView.Scale = new Vector2(scaleValue, scaleValue);
+        spriteView.Scale = new Vector2(scaleValue, scaleValue);
 
         control = spriteView;
         return true;

--- a/Content.Client/_Sunrise/UserInterface/RichText/BaseTextureTag.cs
+++ b/Content.Client/_Sunrise/UserInterface/RichText/BaseTextureTag.cs
@@ -1,0 +1,66 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Robust.Client.GameObjects;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Sunrise.UserInterface.RichText;
+
+public abstract class BaseTextureTag : IMarkupTag
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+
+    public virtual string Name => "example";
+
+    public abstract bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control);
+
+    protected static bool TryDrawIcon(string rawPath, long scaleValue, [NotNullWhen(true)] out Control? control)
+    {
+        var texture = new TextureRect();
+
+        rawPath = ClearString(rawPath);
+
+        texture.TexturePath = rawPath;
+        texture.TextureScale = new Vector2(scaleValue, scaleValue);
+
+        control = texture;
+        return true;
+    }
+
+    protected bool TryDrawIcon(EntProtoId entProtoId, long scaleValue, [NotNullWhen(true)] out Control? control)
+    {
+        control = null;
+        var texture = new TextureRect();
+
+        entProtoId = ClearString(entProtoId);
+
+        if (!_prototypeManager.TryIndex(entProtoId, out var prototype))
+            return false;
+
+        var spriteSystem = _entitySystemManager.GetEntitySystem<SpriteSystem>();
+        texture.Texture = spriteSystem.Frame0(prototype);
+        texture.TextureScale = new Vector2(scaleValue, scaleValue);
+
+        control = texture;
+        return true;
+    }
+
+    /// <summary>
+    /// Очищает строку от мусора, который приходит вместе с ней
+    /// </summary>
+    /// <remarks>
+    /// Почему мне приходят строки в говне
+    /// </remarks>
+    protected static string ClearString(string str)
+    {
+        str = str.Replace("=", "");
+        str = str.Replace("\"", "");
+        str = str.Trim();
+
+        return str;
+    }
+}

--- a/Content.Client/_Sunrise/UserInterface/RichText/BaseTextureTag.cs
+++ b/Content.Client/_Sunrise/UserInterface/RichText/BaseTextureTag.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using Content.Client._Sunrise.UserInterface.Controls;
 using Robust.Client.GameObjects;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
@@ -46,6 +47,27 @@ public abstract class BaseTextureTag : IMarkupTag
         texture.TextureScale = new Vector2(scaleValue, scaleValue);
 
         control = texture;
+        return true;
+    }
+
+    protected static bool TryDrawIconEntity(string stringUid, long scaleValue, [NotNullWhen(true)] out Control? control)
+    {
+        control = null;
+        var spriteView = new SunriseStaticSpriteView()
+        {
+            OverrideDirection = Direction.South,
+            SetSize = new Vector2(48f, 32f),
+        };
+
+        stringUid = ClearString(stringUid);
+
+        if (!EntityUid.TryParse(stringUid, out var entityUid))
+            return false;
+
+        spriteView.SetEntity(entityUid);
+        //spriteView.Scale = new Vector2(scaleValue, scaleValue);
+
+        control = spriteView;
         return true;
     }
 

--- a/Content.Client/_Sunrise/UserInterface/RichText/EntityTextureTag.cs
+++ b/Content.Client/_Sunrise/UserInterface/RichText/EntityTextureTag.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Robust.Client.UserInterface;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Sunrise.UserInterface.RichText;
+
+public sealed class EntityTextureTag : BaseTextureTag
+{
+    public override string Name => "enttex";
+
+    public override bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+    {
+        control = null;
+
+        if (!node.Attributes.TryGetValue("id", out var entProtoId))
+            return false;
+
+        if (!node.Attributes.TryGetValue("scale", out var scale) || !scale.TryGetLong(out var scaleValue))
+        {
+            scaleValue = 1;
+        }
+
+        if (!TryDrawIconEntity((EntProtoId) entProtoId.ToString(), scaleValue.Value, out var texture))
+            return false;
+
+        control = texture;
+
+        return true;
+    }
+}

--- a/Content.Client/_Sunrise/UserInterface/RichText/RadioIconTag.cs
+++ b/Content.Client/_Sunrise/UserInterface/RichText/RadioIconTag.cs
@@ -1,71 +1,52 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using Content.Shared._Sunrise.SunriseCCVars;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
-using Robust.Client.UserInterface.RichText;
 using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
 
 namespace Content.Client._Sunrise.UserInterface.RichText;
 
-public sealed class RadioIconTag : IMarkupTag
+public sealed class RadioIconTag : BaseTextureTag
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IResourceCache _cache = default!;
 
-    public string Name => "radicon";
+    public override string Name => "radicon";
 
-    /// <inheritdoc/>
-    public bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+    public override bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
     {
+        control = null;
+
         if (_cfg.GetCVar(SunriseCCVars.ChatIconsEnable))
         {
             if (!node.Attributes.TryGetValue("path", out var rawPath))
-            {
-                control = null;
                 return false;
-            }
 
             if (!node.Attributes.TryGetValue("scale", out var scale) || !scale.TryGetLong(out var scaleValue))
             {
                 scaleValue = 1;
             }
 
-            control = DrawIcon(rawPath.ToString(), scaleValue.Value);
+            if (!TryDrawIcon(rawPath.ToString(), scaleValue.Value, out var texture))
+                return false;
+
+            control = texture;
         }
         else
         {
             if (!node.Attributes.TryGetValue("text", out var text))
-            {
-                control = null;
                 return false;
-            }
 
             if (!node.Attributes.TryGetValue("color", out var color))
-            {
-                control = null;
                 return false;
-            }
 
             control = DrawText(text.ToString(), color.ToString());
         }
 
         return true;
-    }
-
-    private Control DrawIcon(string path, long scaleValue)
-    {
-        var texture = new TextureRect();
-
-        path = ClearString(path);
-
-        texture.TexturePath = path;
-        texture.TextureScale = new Vector2(scaleValue, scaleValue);
-
-        return texture;
     }
 
     private Control DrawText(string text, string color)
@@ -80,21 +61,6 @@ public sealed class RadioIconTag : IMarkupTag
         label.FontOverride = new VectorFont(_cache.GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Bold.ttf"), 13);
 
         return label;
-    }
-
-    /// <summary>
-    /// Очищает строку от мусора, который приходит вместе с ней
-    /// </summary>
-    /// <remarks>
-    /// Почему мне приходят строки в говне
-    /// </remarks>
-    private static string ClearString(string str)
-    {
-        str = str.Replace("=", "");
-        str = str.Replace("\"", "");
-        str = str.Trim();
-
-        return str;
     }
 
 }

--- a/Content.Client/_Sunrise/UserInterface/RichText/TextureTag.cs
+++ b/Content.Client/_Sunrise/UserInterface/RichText/TextureTag.cs
@@ -1,40 +1,27 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using Robust.Client.UserInterface;
-using Robust.Client.UserInterface.Controls;
-using Robust.Client.UserInterface.RichText;
-
 using Robust.Shared.Utility;
 
 namespace Content.Client._Sunrise.UserInterface.RichText;
 
-public sealed class TextureTag : IMarkupTag
+public sealed class TextureTag : BaseTextureTag
 {
-    public string Name => "tex";
+    public override string Name => "tex";
 
-    /// <inheritdoc/>
-    public bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+    public override bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
     {
+        control = null;
+
         if (!node.Attributes.TryGetValue("path", out var rawPath))
-        {
-            control = null;
             return false;
-        }
 
         if (!node.Attributes.TryGetValue("scale", out var scale) || !scale.TryGetLong(out var scaleValue))
         {
             scaleValue = 1;
         }
 
-        var texture = new TextureRect();
-
-        var path = rawPath.ToString();
-        path = path.Replace("=", "");
-        path = path.Replace(" ", "");
-        path = path.Replace("\"", "");
-
-        texture.TexturePath = path;
-        texture.TextureScale = new Vector2(scaleValue.Value, scaleValue.Value);
+        if (!TryDrawIcon(rawPath.ToString(), scaleValue.Value, out var texture))
+            return false;
 
         control = texture;
         return true;

--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -100,7 +100,9 @@ namespace Content.Server.Pointing.EntitySystems
                 // Someone pointing at YOU is slightly more important
                 var popupType = viewerEntity == pointed ? PopupType.Medium : PopupType.Small;
 
-                RaiseNetworkEvent(new PopupEntityEvent(message, popupType, netSource), viewerEntity);
+                // Sunrise edit start - добавил оригин в виде предмета, на который тыкнули для иконок
+                RaiseNetworkEvent(new PopupEntityEvent(message, popupType, netSource, GetNetEntity(pointed)), viewerEntity);
+                // Sunrise edit end
             }
 
             _replay.RecordServerMessage(new PopupEntityEvent(viewerMessage, PopupType.Small, netSource));

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -124,11 +124,22 @@ namespace Content.Shared.Popups
 
         public PopupType Type { get; }
 
+        public NetEntity? Origin; // Sunrise added
+
         protected PopupEvent(string message, PopupType type)
         {
             Message = message;
             Type = type;
         }
+
+        // Sunrise added start
+        protected PopupEvent(string message, PopupType type, NetEntity origin)
+        {
+            Message = message;
+            Type = type;
+            Origin = origin;
+        }
+        // Sunrise added end
     }
 
     /// <summary>
@@ -168,6 +179,13 @@ namespace Content.Shared.Popups
         {
             Uid = uid;
         }
+
+        // Sunrise added start
+        public PopupEntityEvent(string message, PopupType type, NetEntity uid, NetEntity origin) : base(message, type, origin)
+        {
+            Uid = uid;
+        }
+        // Sunrise added end
     }
 
     /// <summary>

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.cs
@@ -412,4 +412,11 @@ public sealed class SunriseCCVars
 
     public static readonly CVarDef<bool> ChatIconsEnable =
         CVarDef.Create("chat_icon.enable", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /*
+     * Pointing chat visuals
+     */
+
+    public static readonly CVarDef<bool> ChatPointingVisuals =
+        CVarDef.Create("chat_icon_pointing.enable", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/ru-RU/_strings/_sunrise/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/escape-menu/ui/options-menu.ftl
@@ -20,4 +20,5 @@ ui-options-function-reloading = Перезарядка
 ui-options-function-look-up = Присмотреться/Прицелиться
 ui-options-function-auto-get-up = Автоматически вставать при падении
 ui-options-function-hold-look-up = Удерживать клавишу для прицеливания
-ui-options-chat-icons-enable = Использовать иконки в чате
+ui-options-chat-icons-enable = Использовать иконки профессий в чате
+ui-options-chat-pointing-visuals-enable = Отображать указывания с иконками в чате

--- a/Resources/Locale/ru-RU/_strings/_sunrise/tags/entity_texture.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/tags/entity_texture.ftl
@@ -1,0 +1,2 @@
+﻿ent-texture-tag-short = [enttex id="{ $id }"]
+ent-texture-tag = [enttex id="{ $id }" scale={ $scale }]

--- a/Resources/Locale/ru-RU/_strings/entity-systems/pointing/pointing-system.ftl
+++ b/Resources/Locale/ru-RU/_strings/entity-systems/pointing/pointing-system.ftl
@@ -1,10 +1,10 @@
 ## PointingSystem
 
 pointing-system-try-point-cannot-reach = Вы не можете туда достать!
-pointing-system-point-at-self = Вы указываете на себя.
-pointing-system-point-at-other = Вы указываете на { $other }.
-pointing-system-point-at-self-others = { CAPITALIZE($otherName) } указывает на { $other }.
-pointing-system-point-at-other-others = { CAPITALIZE($otherName) } указывает на { $other }.
-pointing-system-point-at-you-other = { $otherName } указывает на вас.
-pointing-system-point-at-tile = Вы указываете на { $tileName }.
-pointing-system-other-point-at-tile = { CAPITALIZE($otherName) } указывает на { $tileName }.
+pointing-system-point-at-self = Вы указываете на себя
+pointing-system-point-at-other = Вы указываете на { $other }
+pointing-system-point-at-self-others = { CAPITALIZE($otherName) } указывает на { $other }
+pointing-system-point-at-other-others = { CAPITALIZE($otherName) } указывает на { $other }
+pointing-system-point-at-you-other = { $otherName } указывает на вас
+pointing-system-point-at-tile = Вы указываете на { $tileName }
+pointing-system-other-point-at-tile = { CAPITALIZE($otherName) } указывает на { $tileName }


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Добавил пару новых возможностей для тегов, чтобы рисовать спрайты по EntityUid и по прототипу ентити
Стандартизировал все текстурные теги и вынес одинаковое в базовый метод
Ну и добавил визуализацию приколов при поинте
А еще добавил статичный спрайт вью, мб еще кому-то пригодится

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

![Screenshot 2025-02-15 234144](https://github.com/user-attachments/assets/d31d840d-5d77-43ca-9cb1-ccea9f745a8a)


**Changelog**

:cl: ThereDrD
- add: Добавлена визуализация и логгирование указывания стрелочкой. Теперь текст этого попапа отображается в чате, а рядом спрайт того, на что было указано. Отключается в настройках