### PR TITLE
Нерф Бипски

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -686,12 +686,12 @@
         amount: 0.15
       # Sunrise-start
       - !type:Electrocute
-        probability: 0.6
+        probability: 0.05
       - !type:PopupMessage
         messages: [ "reagent-beepskysmash-effect1" ]
         type: Pvs
         visualType: LargeCaution
-        probability: 0.8
+        probability: 0.3
       # Sunrise-end
   fizziness: 0.3
 

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -187,10 +187,6 @@
       amount: 1
     Whiskey:
       amount: 1
-    # Sunrise-start
-    Zinc:
-      amount: 1
-    # Sunrise-end
   products:
     BeepskySmash: 2
 


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Нерф Бипски
Теперь бипски это напиток для бара, упрощен крафт но снижен сильно эффект стана.
Больше не должны использовать напиток как боевой реагент

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->

:cl: KaiserMaus
- tweak: напиток "Удар Бипски" теперь не требует цинк но снижен шанс на эффекты.