### PR TITLE
Скафандр "ХАМЕЛЕОН"

### DIFF
--- a/Content.Client/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Client/Clothing/Systems/ChameleonClothingSystem.cs
@@ -13,6 +13,7 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IComponentFactory _factory = default!;
+    [Dependency] private readonly EntityManager _entManager = default!;
 
     private static readonly SlotFlags[] IgnoredSlots =
     {
@@ -52,7 +53,23 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
         {
             sprite.CopyFrom(otherSprite);
         }
+       // Sunrise-start
+        if (!TryComp(uid, out ToggleableClothingComponent? helmet)
+            || !proto.TryGetComponent(out ToggleableClothingComponent? protoHelmet, _factory))
+            return;
 
+        if (!_proto.TryIndex(protoHelmet.ClothingPrototype.Id, out var prototypeHelmetOther))
+            return;
+
+        if (prototypeHelmetOther == null)
+            return;
+
+        if (TryComp(helmet.ClothingUid, out SpriteComponent? helmetSprite)
+            && prototypeHelmetOther.TryGetComponent(out SpriteComponent? otherHelmetSprite, _factory))
+        {
+            helmetSprite.CopyFrom(otherHelmetSprite);
+        }
+        // Sunrise-end
         // Edgecase for PDAs to include visuals when UI is open
         if (TryComp(uid, out PdaBorderColorComponent? borderColor)
             && proto.TryGetComponent(out PdaBorderColorComponent? otherBorderColor, _factory))

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -96,7 +96,53 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
         {
             RemComp<ContrabandComponent>(uid);
         }
+            HelmetUpdate(uid, proto); // Sunrise-edit
     }
+    // Sunrise-start
+    // I know that this is shitcode.
+    // I could subdivide UpdateVisuals into different methods, but I don't want to change the wizden code much
+    public void HelmetUpdate(EntityUid uid, EntityPrototype proto)
+    {
+        if (!TryComp(uid, out ToggleableClothingComponent? helmet))
+            return;
+
+        if (helmet.ClothingUid == null)
+            return;
+
+        if (!proto.TryGetComponent(out ToggleableClothingComponent? protoHelmet, _factory))
+            return;
+
+        if (!_proto.TryIndex(protoHelmet.ClothingPrototype.Id, out var prototypeHelmetOther))
+            return;
+
+        if (TryComp(helmet.ClothingUid, out ClothingComponent? helmetClothing)
+            && prototypeHelmetOther.TryGetComponent(out ClothingComponent? otherHelmetClothing, _factory))
+        {
+            _clothingSystem.CopyVisuals(helmet.ClothingUid.Value, otherHelmetClothing, helmetClothing);
+        }
+        if (TryComp(helmet.ClothingUid, out AppearanceComponent? helmetApperance)
+            && prototypeHelmetOther.TryGetComponent(out AppearanceComponent? otherHelmetApperance, _factory))
+        {
+            _appearance.AppendData(otherHelmetApperance, helmet.ClothingUid.Value);
+            Dirty(uid, helmetApperance);
+        }
+        if (TryComp(helmet.ClothingUid, out MetaDataComponent? meta))
+        {
+            _metaData.SetEntityName(helmet.ClothingUid.Value, prototypeHelmetOther.Name, meta);
+            _metaData.SetEntityDescription(helmet.ClothingUid.Value, prototypeHelmetOther.Description, meta);
+        }
+        if (prototypeHelmetOther.TryGetComponent("Contraband", out ContrabandComponent? contra))
+        {
+            EnsureComp<ContrabandComponent>(helmet.ClothingUid.Value, out var current);
+            _contraband.CopyDetails(helmet.ClothingUid.Value, contra, current);
+        }
+        else
+        {
+            RemComp<ContrabandComponent>(helmet.ClothingUid.Value);
+        }
+
+    }
+    // Sunrise-end
 
     private void OnVerb(Entity<ChameleonClothingComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
     {

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1857,6 +1857,19 @@
   categories:
     - UplinkWearables
 
+- type: listing
+  id: UplinkOuterHardsuitChameleon
+  name: uplink-clothing-outer-hardsuit-chameleon-name
+  description: uplink-clothing-hardsuit-chameleon-desc
+  productEntity: ClothingOuterHardsuitChameleon
+  discountCategory: rareDiscounts
+  discountDownTo: 
+    Telecrystal: 5
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkWearables
+
  # Pointless
 
 - type: listing

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -158,6 +158,7 @@
     - Hardsuit
     - WhitelistChameleon
     - FullBodyOuter # Sunrise-Edit
+    - WhitelistChameleonSuit #Sunrise-edit
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
   - type: DamageOnInteractProtection

--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -445,3 +445,40 @@
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCapSun
   - type: StaticPrice
     price: 0
+
+- type: entity
+  parent: ClothingOuterHardsuitBasic
+  id: ClothingOuterHardsuitChameleon
+  name: syndicate chameleon
+  description: Looking at his material, Sci-fi images inadvertently pop up in your head.
+  components:
+    - type: Tag
+      tags: []
+    - type: Sprite
+      sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
+    - type: Clothing
+      sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.85
+    - type: Biocode
+      factions:
+      - Syndicate
+      - Thief
+    - type: ChameleonClothing
+      slot: [outerClothing]
+      default: ClothingOuterHardsuitBasic
+      requireTag: WhitelistChameleonSuit
+    - type: UserInterface
+      interfaces:
+        enum.ChameleonUiKey.Key:
+          type: ChameleonBoundUserInterface
+    - type: Armor
+      modifiers:
+        coefficients:
+          Blunt: 0.8
+          Slash: 0.55
+          Piercing: 0.65
+          Heat: 0.4
+          Radiation: 0.5
+          Caustic: 0.5

--- a/Resources/Prototypes/_Sunrise/tags.yml
+++ b/Resources/Prototypes/_Sunrise/tags.yml
@@ -344,3 +344,6 @@
 
 - type: Tag
   id: Geranium
+
+- type: Tag
+  id: WhitelistChameleonSuit


### PR DESCRIPTION
## Кратное описание
Введение скафандра "хамелеон" с автозаменой шлема

## По какой причине
Новая экипировка для синдиката, имеется автоматическая замена шлема под установленный скафандр.
Резисты:
Ушибы - 20%
Порезы - 45%
Колющие - 35%
Высокотемпературные - 60%
Радиация - 50%

**Changelog**
:cl: Kendrick
- add: Добавлен скафандр "Хамелеон" в аплинк синдиката.