### PR TITLE
Обновления в сервисном отделе

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -35,6 +35,9 @@
   - type: StorageFill
     contents:
       - id: CrowbarRed
+      - id: Screwdriver #Sunrise-add
+      - id: Wrench #Sunrise-add
+      - id: PaperBin20 #Sunrise-add
       - id: VariantCubeBox
       - id: BoxMousetrap
         amount: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/hydrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/hydrobe.yml
@@ -4,14 +4,15 @@
     ClothingBackpackHydroponics: 2
     ClothingBackpackSatchelHydroponics: 2
     ClothingBackpackDuffelHydroponics: 2
-    ClothingOuterApronBotanist: 2
+    ClothingOuterApronBotanist: 3
     ClothingUniformOveralls: 3
     ClothingUniformJumpsuitHydroponics: 3
     ClothingUniformJumpskirtHydroponics: 3
     ClothingNeckScarfStripedGreen: 3
     ClothingHeadBandBotany: 3
-    ClothingHeadsetService: 2
-    ClothingOuterWinterHydro: 2
+    ClothingHeadsetService: 3 #Sunrise-edit
+    ClothingOuterWinterHydro: 3 #Sunrise-edit
+    ClothingHandsGlovesLeather: 3 #Sunrise-add
   contrabandInventory:
     ToyFigurineBotanist: 1
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -878,13 +878,13 @@
   - type: SolutionContainerManager
     solutions:
       udder:
-        maxVol: 250
+        maxVol: 500 #Sunrise-edit
         reagents:
         - ReagentId: Milk
           Quantity: 30
   - type: Udder
     reagentId: Milk
-    quantityPerUpdate: 25
+    quantityPerUpdate: 50
     growthDelay: 30
   - type: ExaminableHunger
   - type: Butcherable

--- a/Resources/Prototypes/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/Recipes/Lathes/biogen.yml
@@ -2,17 +2,17 @@
   id: BioGenMonkeyCube
   result: MonkeyCube
   category: Food
-  completetime: 3
+  completetime: 10
   materials:
-    Biomass: 70
+    Biomass: 16 #sunrise-edit
 
 - type: latheRecipe
   id: BioGenKoboldCube
   result: KoboldCube
   category: Food
-  completetime: 3
+  completetime: 10
   materials:
-    Biomass: 70
+    Biomass: 16 #sinrise-edit
 
 - type: latheRecipe
   id: BioGenMaterialCloth1
@@ -285,4 +285,52 @@
   materials:
     Biomass: 50
 
+- type: latheRecipe
+  id: BioCowCube
+  result: CowCube
+  completetime: 30
+  materials:
+    Biomass: 240
+
+- type: latheRecipe
+  id: BioGoatCube
+  result: GoatCube
+  completetime: 30
+  materials:
+    Biomass: 75
+
+- type: latheRecipe
+  id: BioMothroachCube
+  result: MothroachCube
+  completetime: 45 # prevent biblical floods
+  materials:
+    Biomass: 20 # a lot of materials wasted due to complex genetics
+
+- type: latheRecipe
+  id: BioMouseCube
+  result: MouseCube
+  completetime: 15
+  materials:
+    Biomass: 12
+
+- type: latheRecipe
+  id: BioCockroachCube
+  result: CockroachCube
+  completetime: 15
+  materials:
+    Biomass: 16
+
+- type: latheRecipe
+  id: BioPigCube
+  result: PigCube
+  completetime: 15
+  materials:
+    Biomass: 55
+
+- type: latheRecipe
+  id: BioChikenCube
+  result: ChikenCube
+  completetime: 15
+  materials:
+    Biomass: 16
 # Sunrise-End

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -91,10 +91,10 @@
     state: display
   discipline: CivilianServices
   tier: 1
-  cost: 7500
+  cost: 4500 #Sunrise-edit
   recipeUnlocks:
   - FatExtractorMachineCircuitboard
-  - BiofabricatorMachineCircuitboard
+  # - BiofabricatorMachineCircuitboard #Sunrise-edit
   - BiomassReclaimerMachineCircuitboard
 
 # Tier 2

--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/biogen.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/biogen.yml
@@ -10,3 +10,10 @@
   - BioClothingBeltJanitor
   - BioClothingBeltStorageWaistbag
   - BioClothingBeltChef
+  - BioCowCube
+  - BioGoatCube
+  - BioMothroachCube
+  - BioMouseCube
+  - BioCockroachCube
+  - BioPigCube
+  - BioChikenCube


### PR DESCRIPTION

## Краткое описание
- В гардероб шеф повара добавлено: гаечный ключ, отвертка, стопка бумаг. 
- Теперь одежда, которую ботаники обязаны носить по срп, есть в их вендинге. (Хз почему не было, но теперь душничи на авд не будут доставать работяг)
- Корова теперь имеет и производит в 2 раза больше молока. 
- Функционал биофабрикатора перенесён в биогенератор. (Не понятно зачем вообще нужно было делать 2 структуры с одинаковой текстурой и функционалом, если изначально нужно было сделать всё в одном биогенераторе, как в сс13. Теперь мясо на прилавках поваров не будет чем то экзотическим и редким, а вполне нормальным явлением)
- Биофабрикатор теперь нельзя изучить

## По какой причине
Меньше духоты, больше простора для ролевых взаимодействий в отделе. Поварам теперь проще открывать ресторан, а взаимодействие с ботаниками стало глубже. Возможно, это повысит популярность роли повара.

## Медиа(Видео/Скриншоты)
![2025-02-22_21h37_33](https://github.com/user-attachments/assets/98b1644d-20c2-4ae6-84be-58636a5f6ee0)

![2025-02-23_10h19_11](https://github.com/user-attachments/assets/9b886787-7fe6-42f7-bf86-aa6ad58a7e90)

**Changelog**

:cl: temm1ie, Zarek
- add: В гардероб шеф-повара добавлены: гаечный ключ, отвертка и стопка бумаг.
- add: Удой коровы увеличен вдвое — теперь они производят в 2 раза больше молока. 
- add: Функционал биофабрикатора перенесён в биогенератор.
- add: Одежда, обязательная для ботаников по СРП, теперь доступна в ГидроРобе.
- remove: Изучение биофабрикатора больше недоступно.

