### PR TITLE
Химия, небольшая редактура.

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1218,7 +1218,7 @@
     Medicine:
       effects:
         - !type:ReduceRotting
-          seconds: 20
+          seconds: 10
           conditions:
           #Patient must be dead and in a cryo tube (or something cold)
           - !type:Temperature

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,14 +561,16 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Mannitol:
+      amount: 1
+    Necrosol: 
       amount: 1
     Plasma:
       amount: 2
     Doxarubixadone:
       amount: 1
   products:
-    Opporozidone: 3
+    Opporozidone: 2
 
 - type: reaction
   id: Necrosol

--- a/Resources/Prototypes/_Sunrise/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Sunrise/Reagents/narcotics.yml
@@ -14,11 +14,11 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 3
+            Poison: 0.65
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 10
+          min: 25
         damage:
           types:
             Poison: 5
@@ -32,17 +32,33 @@
         time: 30
         refresh: true
       - !type:MovespeedModifier
-        walkSpeedModifier: 1.30
-        sprintSpeedModifier: 1.45
+        walkSpeedModifier: 1.35
+        sprintSpeedModifier: 1.50
       - !type:Jitter
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 3.5
+        type: Remove
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 3.5
+        type: Remove
       - !type:PopupMessage
         visualType: Medium
         messages: ["ephedrine-effect-tight-pain", "ephedrine-effect-heart-pounds"]
         type: Local
         probability: 0.25
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Haloperidol
+          max: 0.01
+        key: Drowsiness
+        time: 10
+        type: Remove
     Medicine:
       effects:
       - !type:ResetNarcolepsy
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 20


### PR DESCRIPTION
## Кратное описание
Оппорозидон почти никто не варит. Данный PR сделан чтобы его наконец-то варили

## По какой причине
Увидел предложение в дискорде Рыбы, связался со знающими людьми и отредактировал.

## Медиа(Видео/Скриншоты)


**Changelog**
:cl: Francus_(спасибо agronomys!)
- tweak: Химики НТ открыли новый способ синтеза Оппорозидона! Теперь для него не нужно Когнизина, вместо него хватит Маннитола и Некрозола, однако на выходе выходит меньшее количество итогового вещества!
- tweak: Бафф Дезоантизина. Теперь он наконец-то полезен.
- tweak: Оппорозидон стал расходоваться быстее(в угоду баланса)