### PR TITLE
Игровое время для боргов

### DIFF
--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/clown_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/clown_borg.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobClownBorg
   icon: JobIconClownBorg
   supervisors: job-supervisors-human
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgClownBattery

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/engineer_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/engineer_borg.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobEngineerBorg
   icon: JobIconEngineerBorg
   supervisors: job-supervisors-human
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgEngineerBattery

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/janitor_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/janitor_borg.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobJanitorBorg
   icon: JobIconJanitorBorg
   supervisors: job-supervisors-human
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgJanitorBattery

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/medical_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/medical_borg.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobMedicalBorg
   icon: JobIconMedicalBorg
   supervisors: job-supervisors-human
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgMedicalBattery

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/mining_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/mining_borg.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobMiningBorg
   icon: JobIconMiningBorg
   supervisors: job-supervisors-human
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgMiningBattery

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/peace_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/peace_borg.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobPeaceBorg
   icon: JobIconPeaceBorg
   supervisors: job-supervisors-hos
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgPeaceBattery

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/security_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/security_borg.yml
@@ -5,6 +5,12 @@
   playTimeTracker: JobSecurityBorg
   icon: JobIconSecurityBorg
   supervisors: job-supervisors-hos
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hrs # Sunrise-RoleTime
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgSecurityBattery

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/service_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/service_borg.yml
@@ -5,6 +5,9 @@
   playTimeTracker: JobServiceBorg
   icon: JobIconServiceBorg
   supervisors: job-supervisors-human
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs # Sunrise-Edit
   canBeAntag: false
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgServiceBattery


### PR DESCRIPTION

## Кратное описание
Поставил всем боргам минимальное игровое время до открытия - 20 часов, а боргу СБ сверху накинул 5 часов на СБ
## По какой причине
Защита от набегаторов

## Медиа(Видео/Скриншоты)
![image](https://github.com/user-attachments/assets/44fb4e8b-7034-4271-9811-d681209ef128)

**Changelog**
cl: Francus_
- tweak: Изменено минимальное число времени для открытия всех боргов - теперь это 20 часов общего времени. Для Борга СБ дополнительно 5 часов на СБ.


