### PR TITLE
Ребаланс скорости СБ магниток

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/Shoes/magboots.yml
@@ -42,7 +42,7 @@
     sprite: _Sunrise/Clothing/Shoes/magboots-sec.rsi
   - type: Magboots
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.7
+    walkModifier: 0.85
+    sprintModifier: 0.8
   - type: ClothingSlowOnDamageModifier
     modifier: 0.75


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Изменение скорости бега и ходьбы у СБ магниток

## По какой причине
Была предложка с ДС сервера. А так, по логике описания, мол, раз это просто перекрашеные простые магнитки, но под СБ, то скорость по сути должна оставаться такой же как и у простых.

## Медиа(Видео/Скриншоты)
Скину скриншот через имгур

**Changelog**
:cl: SqerDust:
- tweak: Изменил скорость бега магниток СБ до 20% и ходьбы до 15%
