### PR TITLE
Добавление изучения Магбутсов СБ в РНД

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -363,6 +363,7 @@
     - id: ClothingMaskGasSwat
     - id: ClothingOuterHardsuitSecurityRed
     - id: ClothingShoesBootsMagSec  # Sunrise-edit
+      prob: 0.3
     - id: JetpackSecurityFilled
     - id: OxygenTankFilled
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -155,6 +155,7 @@
         - id: ClothingOuterHardsuitSecurity
         - id: ClothingMaskBreath
         - id: ClothingShoesBootsMagSec  # Sunrise-edit
+          prob: 0.3
   - type: AccessReader
     access: [["Security"]]
 
@@ -222,6 +223,7 @@
         - id: ClothingOuterHardsuitWarden
         - id: ClothingMaskBreath
         - id: ClothingShoesBootsMagSec  # Sunrise-edit
+          prob: 0.5
   - type: AccessReader
     access: [["Armory"]]
 

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -69,6 +69,7 @@
   cost: 7500
   recipeUnlocks:
   - ClothingShoesBootsMagSci
+  - ClothingShoesBootsMagSec #Sunrise-Add
   - ClothingShoesBootsMoon
 
 - type: technology

--- a/Resources/Prototypes/_Sunrise/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Fills/Lockers/suit_storage.yml
@@ -9,6 +9,7 @@
     - id: ClothingOuterHardsuitBlueshield
     - id: ClothingMaskGas
     - id: ClothingShoesBootsMagSec
+      prob: 0.5
   - type: AccessReader
     access: [["BlueShield"]]
 
@@ -24,6 +25,7 @@
         - id: ClothingOuterHardsuitSecuritySunrise
         - id: ClothingMaskBreath
         - id: ClothingShoesBootsMagSec
+          prob: 0.3
   - type: AccessReader
     access: [["Security"]]
 

--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/Packs/security.yml
@@ -51,4 +51,5 @@
     - EnergyDomeDirectionalTurtle
     - ClothingHeadHelmetPubg
     - ClothingShoesBootsMagCombat
+    - ClothingShoesBootsMagSec
     - WeaponTemperatureGun

--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/misc.yml
@@ -15,3 +15,11 @@
     Steel: 6000
     Glass: 3000
     Plastic: 600
+
+- type: latheRecipe
+  id: ClothingShoesBootsMagSec
+  result: ClothingShoesBootsMagSec
+  completetime: 30
+  materials:
+    Steel: 1000
+    Plastic: 500


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Возврат шансов на магнитные ботинки в каждый шкаф вместо гарантированного спавна
Добавление СБ магниток в технологию магниток и производство исключительно на фабе СБ


## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Шансы возвращены ибо часто игроки раундстарт берут "манчат" ботинки ради NoSlip компонента.
Так же их усилят в ПРе https://github.com/space-sunrise/space-station-14/pull/1515 что в свою очередь только сильнее подстегнёт powergaming в СБ

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- add: Добавлены Изучение и Производство Магнитных ботинок СБ.
- tweak: NT в очередной раз сократило бюджет СБ.