### PR TITLE
Удаление генокрадов, вампиров и воров из пресета нюки

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -194,7 +194,6 @@
   minPlayers: 20 # Sunrise-Edit: 20 players for NUKEOPS
   rules:
     - Nukeops
-    - LiteSubGamemodesRule # Только лайтовые под-антаги, чтобы не было кооперации станции с генокрадами против ЯО.
     - BasicStationEventScheduler
     - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Удалить воров, генокрадов, вампиров из пресета ЯО

## По какой причине
- Станция нередко коопирируется с генокрадами и вампирами. Генокрады фактически бессмертны, имеют бесконечный запас стимулятора, укусы, которые наносят внушительный урон ядами и замедляют оперативников.
- Вампиры не гниют, имеют способности, позволяющие на секунду оглушить оперативника.
- Воры имеют набор, в котором имеется гипоручка с ноктюрином, благодаря которому они усыпляют оперативников, тем самым полностью их обезвреживая.
- К тому же вышеперечисленные антагонисты порой решают выполнить свои цели под шум от ЯО, из-за чего гадят станции в и так трудную для них обстановку.

**Changelog**

:cl: VigersRay
- remove: Удалены антагонисты из режима ядерных оперативников.
