### PR TITLE
Обновление ОСЩ по предложке

### DIFF
--- a/Resources/Prototypes/_Sunrise/Catalog/Fills/Lockers/blueshield.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Fills/Lockers/blueshield.yml
@@ -9,7 +9,7 @@
       - id: ClothingHeadsetAltCommand
       - id: CigarGoldCase
         prob: 0.25
-      - id: ClothingMaskGasSecurity
+      - id: ClothingMaskGasSwat
       - id: TrackingImplanter
         amount: 8
 
@@ -24,7 +24,7 @@
       - id: ClothingHeadsetAltCommand
       - id: CigarGoldCase
         prob: 0.25
-      - id: ClothingMaskGasSecurity
+      - id: ClothingMaskGasSwat
       - id: TrackingImplanter
         amount: 8
 
@@ -40,7 +40,7 @@
       - id: CigarGoldCase
         prob: 0.25
       - id: WeaponEnergyGunMultiphase
-      - id: ClothingMaskGasSecurity
+      - id: ClothingMaskGasSwat
       - id: TrackingImplanter
         amount: 8
 
@@ -55,7 +55,7 @@
     - id: ClothingHeadsetAltCommand
     - id: CigarGoldCase
       prob: 0.25
-    - id: ClothingMaskGasSecurity
+    - id: ClothingMaskGasSwat
     - id: TrackingImplanter
       amount: 8
     - id: ClothingOuterHardsuitBlueshield

--- a/Resources/Prototypes/_Sunrise/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/role_loadouts.yml
@@ -84,7 +84,7 @@
   - BlueShieldJumpsuit
   - BlueShieldBackpack
   - Trinkets
-  - Survival
+  - SurvivalSecurity
   - GroupSpeciesBreathTool
   - Bra
   - Pants


### PR DESCRIPTION

## Кратное описание
Заменил обычный противогаз в хранилище скафандра на противогаз спецназа
Поменял аварийный набор на набор сб (противогаз сб и двойной балон, вместо обычного)

## По какой причине
https://discordapp.com/channels/1174575355370160190/1348631720353726484

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
:cl: Francus_
- tweak: NanoTrasen расщедрились! Теперь они выделяют всем Офицерам "Синий Щит" на станции Противогазы Спецназа.
- tweak: Теперь NanoTrasen кладёт всем Офицерам "Синий Щит" аварийный набор СБ вместо обычного аварийного набора.