### PR TITLE
Added time requirements for other borgs

### DIFF
--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/clown_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/clown_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgClownBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/engineer_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/engineer_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgEngineerBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/janitor_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/janitor_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgJanitorBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/medical_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/medical_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgMedicalBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/mining_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/mining_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgMiningBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/peace_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/peace_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgPeaceBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/security_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/security_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgSecurityBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/service_borg.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Silicons/service_borg.yml
@@ -9,3 +9,6 @@
   displayWeight: -10  # Sunrise
   jobEntity: PlayerBorgServiceBattery
   overrideConsoleVisibility: false
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 72000 #20 hrs # Sunrise-Edit


### PR DESCRIPTION
Важно принять ПР, поскольку Модерация сообщила (спасибо Сметане), что набегаторы часто юзают боргов + спамят с их помощью очень жёстко

cl: SplikZerys
- add: Добавлено требование 20 часов общего игрового времени для боргов.