### PR TITLE
Провод доступа в консоли

### DIFF
--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -189,6 +189,7 @@
   wires:
   - !type:PowerWireAction
   - !type:AiInteractWireAction
+  -  !type:AccessWireAction
 
 - type: wireLayout
   id: Holopad

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -185,7 +185,7 @@
 
 - type: wireLayout
   id: ComputerAi
-  dummyWires: 2
+  dummyWires: 7
   wires:
   - !type:PowerWireAction
   - !type:AiInteractWireAction


### PR DESCRIPTION
## Кратное описание
Добавил провод доступа в консоли

## По какой причине
Бывают такие случаи(обычно это связано с карго),что нет ни капитана, ни гп, ни кма и одобрять заказы некому(и меня это бесило), поэтому я хочу, что бы в консолях был провод доступа

## Медиа(Видео/Скриншоты)
![image](https://github.com/user-attachments/assets/0922560a-e0c8-4179-b380-9236b8de0443)
![image](https://github.com/user-attachments/assets/a0c87324-3aab-4a7b-bff1-528110b2bbe7)


**Changelog**

:cl: ARMAN007aa

- tweak: В консолях теперь есть провод, отвечающий за доступ
- tweak: Изменено количество проводов в консолях


