### PR TITLE
Убрать мешки с землей из каталога карго

### DIFF
--- a/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_hydroponics.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_hydroponics.yml
@@ -1,12 +1,12 @@
-﻿- type: cargoProduct
-  id: HandheldSoil
-  icon:
-    sprite: _Sunrise/Objects/Misc/soil.rsi
-    state: item
-  product: HandheldSoil
-  cost: 400
-  category: cargoproduct-category-name-hydroponics
-  group: market
+﻿#- type: cargoProduct
+#  id: HandheldSoil
+#  icon:
+#    sprite: _Sunrise/Objects/Misc/soil.rsi
+#    state: item
+#  product: HandheldSoil
+#  cost: 400
+#  category: cargoproduct-category-name-hydroponics
+#  group: market
 
 - type: cargoProduct
   id: HydroponicsSeedsMinimal


### PR DESCRIPTION
## По какой причине
1. Они ломают геймдизайн взаимодействия отделов, а в частности карго-ботаника-кухня. Вместо того, чтобы относить заказ ботаникам/поварам и давать тем геймплей, они покупают мешки с землей за жалкие 400 кредитов и устраивают у себя поля, в последствии намного быстрее выполняя заказы.
2. Легкое обогащение с помощью полей. Ботаника способна создавать кучу бабок множеством способов, умельцы с дешёвыми мешками земли проворачивают множество схем, начиная от хилиумных полей, заканчивая бесконечным золотом.  
![photo_5420267604389523047_y](https://github.com/user-attachments/assets/4c1c3cc6-ee25-43d0-b73c-eaf98eb4d87c)
![photo_5420267604389523046_y](https://github.com/user-attachments/assets/e1da62b9-20a1-42de-b851-6d1608bc2a42)
3. Мешок с землей можно создать в биогенераторе за 100 биомассы. Да, это дорого, но это справедливая цена за целый ботанический лоток, в последствии, я возможно понижу цену за них.
**Changelog**
:cl: temm1ie
- remove: Мешки с землей больше нельзя купить в карго.


