### PR TITLE
[REMOVE] Удаление TTS Валтос в связи с его недоступностью

### DIFF
--- a/Resources/Locale/en-US/_strings/_sunrise/tts/tts-voices.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/tts/tts-voices.ftl
@@ -61,7 +61,6 @@ tts-voice-name-tf-medic = [Team Fortress 2] Медик
 tts-voice-name-tf-sniper = [Team Fortress 2] Снайпер
 tts-voice-name-tf-spy = [Team Fortress 2] Шпион
 tts-voice-name-tf-demoman = [Team Fortress 2] Подрывник
-tts-voice-name-valtos = [Диктор] Валтос
 tts-voice-name-khajiit = [Skyrim] Каджит
 tts-voice-name-punisher = [The Punisher] Каратель
 tts-voice-name-johnny = [Cyberpunk 2077] Джонни Сильверхенд

--- a/Resources/Locale/ru-RU/_strings/_sunrise/tts/tts-voices.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/tts/tts-voices.ftl
@@ -61,7 +61,6 @@ tts-voice-name-tf-medic = [Team Fortress 2] Медик
 tts-voice-name-tf-sniper = [Team Fortress 2] Снайпер
 tts-voice-name-tf-spy = [Team Fortress 2] Шпион
 tts-voice-name-tf-demoman = [Team Fortress 2] Подрывник
-tts-voice-name-valtos = [Диктор] Валтос
 tts-voice-name-khajiit = [Skyrim] Каджит
 tts-voice-name-punisher = [The Punisher] Каратель
 tts-voice-name-johnny = [Cyberpunk 2077] Джонни Сильверхенд

--- a/Resources/Prototypes/_Sunrise/tts-voices.yml
+++ b/Resources/Prototypes/_Sunrise/tts-voices.yml
@@ -400,13 +400,6 @@
   provider: ntts.fdev.team
 
 - type: ttsVoice
-  id: Valtos
-  name: tts-voice-name-valtos
-  sex: Female
-  speaker: valtos
-  provider: ntts.fdev.team
-
-- type: ttsVoice
   id: Khajiit
   name: tts-voice-name-khajiit
   sex: Male


### PR DESCRIPTION
## Кратное описание
Удаление TTS Валтос в связи с его недоступностью

## По какой причине
- Неработоспособность его в игре (превью в лобби работает, в самой игре - другой голос)
- Отсутствие голоса в списке доступных голосов на [сайте](https://ntts.fdev.team/voices)

**Changelog**

:cl: Ne0shka
- remove: Удалён TTS Валтос в связи с отключением данного голоса провайдером
