### PR TITLE
Удаление антагов из нюк опса

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -194,8 +194,7 @@
   minPlayers: 20 # Sunrise-Edit: 20 players for NUKEOPS
   rules:
   - Nukeops
-  - DummyNonAntagChance
-  - SubGamemodesRule
+  - DummyNonAntagChance #sunrise-edit
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Удаление антагов из нюк опса

## По какой причине
Доработка прошлого пулл реквеста с таким же содержанием

**Changelog**

:cl: Kendrick
- remove: Антагонисты ТОЧНО удалены из пресета ядерных оперативников
