### PR TITLE
Удалил минор антагов из революции

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -214,7 +214,6 @@
   rules:
   - DummyNonAntagChance
   - Revolutionary
-  - SubGamemodesRule
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Удаление воров, генокрадов, вампиров из революции.

## По какой причине
Революция - полноценный режим, которому не нужно подкрепление минорных антагонистов

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: Kendrick
- remove: В революции больше не будет воров, вампиров и генокрадов.