### PR TITLE
Дебафф лазера ИСН

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -249,9 +249,9 @@
     startingCharge: 720
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 145
+    autoRechargeRate: 40
     autoRechargePause: true
-    autoRechargePauseTime: 4
+    autoRechargePauseTime: 25
   - type: EnergyGunFireModes
     fireModes:
     - hitscanProto: BulletDisabler


### PR DESCRIPTION

## Кратное описание
Понизил скорость автозарядки для лазера ИСН

## По какой причине
Попросили + слишком имбово, что агенты убивают ИСН ради этого лазера
## Медиа(Видео/Скриншоты)


**Changelog**

:cl: Prototype0308
- tweak: Импульсный револьвер получил замедление. Скорость зарядки 145 -> 40; Пауза зарядки 4 -> 25

