### PR TITLE
Изолированные перчатки больше не позволяют использовать большинство дальнего оружия.

### DIFF
--- a/Content.Shared/Electrocution/InsulatedComponent.cs
+++ b/Content.Shared/Electrocution/InsulatedComponent.cs
@@ -13,5 +13,14 @@ namespace Content.Shared.Electrocution
         /// </summary>
         [DataField, AutoNetworkedField]
         public float Coefficient { get; set; } = 0f;
+
+        // Sunrise-Start
+        /// <summary>
+        /// Whether or not someone with
+        /// Insulated gloves can opperate guns
+        /// </summary>
+        [DataField]
+        public bool PreventOpperatinGuns = false;
+        // Sunrise-End
     }
 }

--- a/Content.Shared/Electrocution/InsulatedSystem.cs
+++ b/Content.Shared/Electrocution/InsulatedSystem.cs
@@ -1,0 +1,24 @@
+// Transfer of closed PR of Wizards 31841
+using Content.Shared.Inventory;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Popups;
+
+namespace Content.Shared.Electrocution;
+
+public sealed partial class InsulatedSystem : EntitySystem
+{
+    [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<InsulatedComponent, InventoryRelayedEvent<ShotAttemptedEvent>>(OnShoot);
+    }
+    private void OnShoot(EntityUid uid, InsulatedComponent comp, ref InventoryRelayedEvent<ShotAttemptedEvent> args)
+    {
+        if (comp.PreventOpperatinGuns && !args.Args.Used.Comp.BigTrigger)
+        {
+            PopupSystem.PopupClient(Loc.GetString("gun-Insulated-gloves"), args.Args.User);
+            args.Args.Cancel();
+        }
+    }
+}

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -23,6 +23,7 @@ using Content.Shared.Temperature;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared._Sunrise.Eye.NightVision.Components;
+using Content.Shared.Weapons.Ranged.Events; // Sunrise-Edit
 
 namespace Content.Shared.Inventory;
 
@@ -54,6 +55,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, GetSpeedModifierContactCapEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, GetSlowedOverSlipperyModifierEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, ModifySlowOnDamageSpeedEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, ShotAttemptedEvent>(RefRelayInventoryEvent); // Sunrise-Edit
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -263,6 +263,15 @@ public sealed partial class GunComponent : Component
     /// </summary>
     [DataField]
     public Vector2 DefaultDirection = new Vector2(0, -1);
+
+    // Sunrise-Start
+    /// <summary>
+    /// Whether or not someone with
+    /// Insulated gloves can opperate this gun
+    /// </summary>
+    [DataField]
+    public bool BigTrigger = false;
+    // Sunrise-End
 }
 
 [Flags]

--- a/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Inventory; // Sunrise-Edit
 
 namespace Content.Shared.Weapons.Ranged.Events;
 
@@ -7,8 +8,9 @@ namespace Content.Shared.Weapons.Ranged.Events;
 /// Cancel this event to prevent it from shooting.
 /// </summary>
 [ByRefEvent]
-public record struct ShotAttemptedEvent
+public record struct ShotAttemptedEvent : IInventoryRelayEvent // Sunrise-Edit
 {
+    SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.GLOVES; // Sunrise-Edit
     /// <summary>
     /// The user attempting to shoot the gun.
     /// </summary>

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -337,6 +337,7 @@
     spawned:
     - id: ClothingHandsGlovesFingerlessInsulated
   - type: Insulated
+    preventOpperatinGuns: true # Sunrise-Edit
   - type: Fiber
     fiberMaterial: fibers-insulative
     fiberColor: fibers-yellow
@@ -348,6 +349,8 @@
   name: budget insulated gloves
   description: These gloves are cheap knockoffs of the coveted ones - no way this can end badly.
   components:
+  - type: Insulated
+    preventOpperatinGuns: true # Sunrise-Edit
   - type: RandomInsulation
     # Why repeated numbers? So some numbers are more common, of course!
     list:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -305,6 +305,7 @@
     fireRate: 4 #No reason to stifle the firerate since you have to manually reload every time anyways.
     soundGunshot:
       collection: m3 # Sunrise-Edit
+    bigTrigger: true # Sunrise-Edit
   - type: BallisticAmmoProvider
     capacity: 1
     proto: null

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
@@ -46,6 +46,7 @@
       - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/flaregun.ogg
+    bigTrigger: true # Sunrise-Edit
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -29,6 +29,7 @@
     soundEmpty:
       path: /Audio/Items/hiss.ogg
     clumsyProof: true
+    bigTrigger: true # Sunrise-Edit
   - type: ContainerAmmoProvider
     container: storagebase
   - type: PneumaticCannon
@@ -92,6 +93,7 @@
     soundEmpty:
       path: /Audio/Items/hiss.ogg
     clumsyProof: true
+    bigTrigger: true # Sunrise-Edit
   - type: ContainerAmmoProvider
     container: storagebase
   - type: Item

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Service/toys-syndi-clown.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Service/toys-syndi-clown.yml
@@ -30,17 +30,12 @@
       path: /Audio/Items/hiss.ogg
     clumsyProof: true
     bigTrigger: true
-  - type: ProjectileBatteryAmmoProvider
-    proto: FoodPieBananaCream
-    fireCost: 75
   - type: Tag
     tags:
     - Sidearm
-  - type: Battery
-    maxCharge: 300
-    startingCharge: 300 # Да, ЭМИ разряжает пироги, как по мне баланс
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 50
-    autoRechargePause: true
-    autoRechargePauseTime: 5
+  - type: BasicEntityAmmoProvider
+    proto: FoodPieBananaCream
+    capacity: 4
+    count: 4
+  - type: RechargeBasicEntityAmmo
+    rechargeCooldown: 3

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Service/toys-syndi-clown.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Service/toys-syndi-clown.yml
@@ -29,9 +29,10 @@
     soundEmpty:
       path: /Audio/Items/hiss.ogg
     clumsyProof: true
+    bigTrigger: true
   - type: ProjectileBatteryAmmoProvider
     proto: FoodPieBananaCream
-    fireCost: 100
+    fireCost: 75
   - type: Tag
     tags:
     - Sidearm
@@ -42,4 +43,4 @@
     autoRecharge: true
     autoRechargeRate: 50
     autoRechargePause: true
-    autoRechargePauseTime: 15
+    autoRechargePauseTime: 5


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Перенос ПРа визардов https://github.com/space-wizards/space-station-14/pull/31841 Изолированные перчатки больше не позволяют использовать большинство дальнего оружия.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Изолированные перчатки больше не позволяют использовать большинство дальнего оружия.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
Изолированные перчатки больше не позволяют использовать большинство дальнего оружия.

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: banumbas (jorgun)
- add: Изолированные перчатки больше не позволяют использовать большинство дальнего оружия.
- tweak: Был баффнут синди-пирогомёт клоуна.