### PR TITLE
Лазер ИСН - более адекватные статки

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -239,7 +239,7 @@
   - type: Clothing
     sprite: _Sunrise/Objects/Weapons/Guns/Battery/pulse_revolver.rsi
   - type: Gun
-    fireRate: 2.75
+    fireRate: 2
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
     soundEmpty:
@@ -249,9 +249,9 @@
     startingCharge: 720
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 40
+    autoRechargeRate: 60
     autoRechargePause: true
-    autoRechargePauseTime: 25
+    autoRechargePauseTime: 6
   - type: EnergyGunFireModes
     fireModes:
     - hitscanProto: BulletDisabler


### PR DESCRIPTION


## Кратное описание
Чутка убил лазер ИСН в 0 и советуясь с людьми поумнее довёл баланс до ума

## По какой причине
Попросили

**Changelog**

:cl: Prototype0308

- tweak: Баланс револьвера был снова изменен. Скорострельность 2.75 -> 2, Задержка зарядки 25 -> 6 ( Ранее 4 ), Скорость зарядки 40 -> 60 ( ранее 145 )

