### PR TITLE
БОКСА БОЛЬШЕ НЕТ

### DIFF
--- a/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
@@ -2,7 +2,6 @@
   id: SunriseMapPool
   maps:
   - SunriseDelta
-  - SunriseBox
   - SunriseFland
   - SunriseMarathon
   - SunriseBagel
@@ -12,6 +11,7 @@
   - SunriseOasis
   - SunriseConvex
   - SunriseLoop
+  #- SunriseBox БОКСА БОЛЬШЕ НЕТ
   # Неиграбельно
   #- SunriseReach
   #- SunriseCorvaxGelta


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
24/7 все игроки выбирают Бокс. Зачем? Почему? Не ясно! Коллегия Бокса приняла ответственное решение вывести карту из игры до той поры, пока разработчики не сделают систему на динамичный пулл карт или пока игроки не научаться играть на других картах КРОМЕ Бокса. 

## По какой причине
Если зайти в канал #Раунды на Санрайзе, то из условных десяти смен, семь будет отыграно на Боксе, ещё две - на дельте и ещё одна на Фланде. Я не понимаю смысла играть на карте, которую знаешь как свои пять пальцев. Вчера был раунд на Конвексе - игроки почувствовали хоть что-то необычное в сравнении с базовыми картами, когда не знали куда идти, не знали что делать. Рано или поздно выучат все карты, а Бокс вернётся как только будет доработан @Odleer и как только будет добавлена вторая версия Бокса. 

## Медиа(Видео/Скриншоты)
-

**Changelog**

:cl: Francus_ 
- remove: В результате атаки Ядерных Оперативников Синдиката, Бокс был уничтожен взрывом ядерной боеголовки. Инженеры уже работают над восстановлением, но какое-то время его не будет(выведен из пулла карт).
