### PR TITLE
BOX

### DIFF
--- a/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
@@ -5,13 +5,13 @@
   - SunriseFland
   - SunriseMarathon
   - SunriseBagel
+  - SunriseBox
   - SunriseMeta
   - SunrisePlasma
   - SunrisePacked
   - SunriseOasis
   - SunriseConvex
   - SunriseLoop
-  #- SunriseBox БОКСА БОЛЬШЕ НЕТ
   # Неиграбельно
   #- SunriseReach
   #- SunriseCorvaxGelta


### PR DESCRIPTION

## Кратное описание

## По какой причине


## Медиа(Видео/Скриншоты)


**Changelog**

:cl: Francus_
- fix: Инженеры НТ передумали и восстановили Бокс раньше намеченного срока(Бокс снова в пулле карт)
