### PR TITLE
Дебаф культистов плоти

### DIFF
--- a/Content.Shared/_Sunrise/FleshCult/FleshCultistComponent.cs
+++ b/Content.Shared/_Sunrise/FleshCult/FleshCultistComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class FleshCultistComponent : Component
     public string ActionFleshCultistShop = "FleshCultistShop";
 
     [DataField]
-    public FixedPoint2 StartingMutationPoints = 5;
+    public FixedPoint2 StartingMutationPoints = 3;
 
     [DataField]
     public EntityUid? ActionFleshCultistShopEntity;

--- a/Resources/Prototypes/_Sunrise/FleshCult/roundstart.yml
+++ b/Resources/Prototypes/_Sunrise/FleshCult/roundstart.yml
@@ -20,7 +20,7 @@
       startingGear: FleshCultistLeaderGear
       components:
       - type: FleshCultist
-        startingMutationPoints: 15
+        startingMutationPoints: 7
       - type: NpcFactionMember
         factions:
         - FleshHuman
@@ -50,7 +50,7 @@
       playerRatio: 15
       components:
       - type: FleshCultist
-        startingMutationPoints: 5
+        startingMutationPoints: 3
       - type: NpcFactionMember
         factions:
         - FleshHuman


### PR DESCRIPTION
Зачем? Лидер может раундстартом купить половину магазина

:cl: pacable
- tweak: Раундстартовое количество очков у культистов плоти было понижено 15 -> 7 у лидера и 5 -> 3 у обычного культиста.
