### PR TITLE
Внешний доступ парамедикам

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -17,6 +17,7 @@
   access:
   - Medical
   - Maintenance
+  - External # Sunrise-Add
   extendedAccess:
   - Chemistry
 


### PR DESCRIPTION
## Кратное описание
Парамедикам добавлен внешний доступ

## По какой причине
Скафы чтобы гулять по разгермам и космосу есть, а доступа выходить в космос нету. Теперь парамедики смогут самостоятельно достать труп, а не просить инженеров или утилей.


**Changelog**
:cl: temm1ie
- add: Парамедикам дан внешний доступ.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Для роли Парамедика добавлен доступ к внешним зонам.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->