### PR TITLE
Camera deconstruction drops LV wires

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cameras.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cameras.yml
@@ -50,6 +50,9 @@
             - !type:GivePrototype
               prototype: SheetSteel1
               amount: 2
+            - !type:GivePrototype
+              prototype: CableApcStack1
+              amount: 1
             - !type:DeleteEntity {}
           steps:
             - tool: Welding


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Фикс бага при разборке камеры, теперь выпадает не только сталь, но и нв провода, что участвуют в крафте.

## По какой причине
Ссылка на багрепорт на дс сервере LUST STATION: https://discord.com/channels/1253315855731916821/1398788239199961214
Это поможет не терять лишний раз НВ провода, когда переставляешь камеры.

<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * При разборке камеры наблюдения теперь дополнительно возвращается один кабель APC вместе с листами стали.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->