### PR TITLE
Добавление возможности удалить лишние названия предметов из умного холодильника

### DIFF
--- a/Content.Shared/SmartFridge/SmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SmartFridgeSystem.cs
@@ -134,11 +134,13 @@ public sealed class SmartFridgeSystem : EntitySystem
             return;
         }
 
-        ent.Comp.ContainedEntries.Remove(args.Entry);
-        ent.Comp.Entries.Remove(args.Entry);
+        if (contained.Count == 0)
+        {
+            ent.Comp.ContainedEntries.Remove(args.Entry);
+            ent.Comp.Entries.Remove(args.Entry);
 
-        Dirty(ent);
-
+            Dirty(ent);
+        }
         _audio.PlayPredicted(ent.Comp.SoundDeny, ent, args.Actor);
         _popup.PopupPredicted(Loc.GetString("smart-fridge-component-try-eject-out-of-stock"), ent, args.Actor);
     }


### PR DESCRIPTION
## Кратное описание
Возможность удалить название предмета из списка умного холодильника

## По какой причине
В случае добавления ненужных кувшинов отсутствует механика удаления лишних названий как "кувшин (углерод)", что может привести к забиванию холодильника лишними названиями.

## Медиа


https://github.com/user-attachments/assets/ee88c259-a93c-41a9-bafe-970673342935

**Changelog**
:cl: Sidzaru
- add: Добавлена возможность удаления предметов из списка умного холодильника


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Умный холодильник теперь корректно удаляет пустые позиции после попытки выдачи, сразу отражая состояние «нет в наличии».
  * Уведомление и звук отказа стабильно воспроизводятся при отсутствии товара.
  * Исключены «залипшие» или дублирующиеся позиции в списке товаров за счёт своевременной очистки.
  * Повышена надёжность логики выдачи без изменения поведения при успешной выдаче и проверках доступа.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->