### PR TITLE
Fixes bug with masks

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
@@ -65,7 +65,7 @@ public sealed class MaskSystem : EntitySystem
         if (!mask.IsToggled || !mask.IsToggleable)
             return;
 
-        mask.IsToggled = false;
+        SetToggled((uid, mask), false, force: true); // Sunrise-Edit
         ToggleMaskComponents(uid, mask, args.Equipee, mask.EquippedPrefix, true);
     }
 


### PR DESCRIPTION
## Кратное описание
Исправления визуального бага с отображением масок

## По какой причине
https://github.com/space-sunrise/lust-station/issues/241

## Медиа

https://github.com/user-attachments/assets/fa5fed67-9824-4f99-ab9a-fecfb7c7028d


https://github.com/user-attachments/assets/dd2c8978-ec25-40eb-8c72-1a9defb26481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Исправления ошибок
  - Маски теперь корректно деактивируются при снятии, исключая ситуации, когда эффект оставался включённым.
  - Состояние действий и индикаторы статуса синхронизируются сразу после снятия маски, устраняя визуальные несоответствия.
  - Обновляется отображение префикса экипировки при снятии, чтобы интерфейс точно отражал текущее состояние.
  - Снижены редкие случаи «залипания» состояния маски и последующих ошибок взаимодействия.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->