### PR TITLE
Borg bug fix

### DIFF
--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -49,6 +49,7 @@
   - type: InputMover
   - type: Examiner
   - type: BlockMovement
+    blockInteraction: false
   - type: BadFood
   - type: Tag
     tags:
@@ -74,7 +75,7 @@
   - type: Item
     size: Small
     heldPrefix: brain
-  
+
 - type: entity
   id: OrganHumanEyes
   parent: [BaseHumanOrgan, BaseOrganEyes]

--- a/Resources/Prototypes/_Sunrise/Body/Organs/predator.yml
+++ b/Resources/Prototypes/_Sunrise/Body/Organs/predator.yml
@@ -50,6 +50,7 @@
   - type: InputMover
   - type: Examiner
   - type: BlockMovement
+    blockInteraction: false
   - type: BadFood
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Robotics/borg_brains.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Robotics/borg_brains.yml
@@ -29,6 +29,7 @@
     stopSearchVerbPopup: boris-stopped-searching
     job: Borg
   - type: BlockMovement
+    blockInteraction: false
   - type: Examiner
   - type: BorgBrain
   - type: IntrinsicRadioReceiver


### PR DESCRIPTION
## Кратное описание
Исправление проблемы с установкой мозга в боргов

## По какой причине
Невозможность установки мозга в киборгов и перемещения ЦИИ из интелликарда 
space-sunrise/sunrise-station/issues/3086

## Медиа

https://github.com/user-attachments/assets/aa7ddd17-83e1-491b-a132-9ba8891a2cd6



**Changelog**
:cl: Sidzaru
- fix: В киборгов вновь можно вставить мозг


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Исправления ошибок
  - Мозги людей, хищников и киборгов больше не блокируют взаимодействия с объектами и устройствами, если находятся на пути (они по‑прежнему могут препятствовать движению, но не мешают кликам/использованию).
  - Устранены редкие случаи, когда из-за мозгов было невозможно взаимодействовать с предметами позади них.
  - Небольшие косметические правки описаний без влияния на геймплей.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->