### PR TITLE
CM cant be moved

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/supermatter.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/supermatter.yml
@@ -11,8 +11,6 @@
     anchored: true
   - type: InteractionOutline
   - type: Clickable
-  - type: Anchorable
-    delay: 2
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -27,7 +25,6 @@
         - FullTileMask
         layer:
         - FullTileLayer
-  - type: Pullable
   - type: Sprite
     sprite: _Starlight/Objects/Specific/supermatter.rsi
     layers:


### PR DESCRIPTION
## Кратное описание
Фиксирование местоположения СМ
## По какой причине
https://github.com/space-sunrise/sunrise-station/issues/3106

**Changelog**
:cl: Sidzaru
- tweak: СМ не может быть откручен и перемещён



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Исправления ошибок**
  - Кристалл суперматерии больше нельзя перетаскивать или откручивать/закреплять инструментами — он теперь неподвижен, что предотвращает непреднамеренное перемещение.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->