### PR TITLE
Hair dyer verb texture fix

### DIFF
--- a/Content.Server/_Sunrise/HairDye/HairDyeSystem.cs
+++ b/Content.Server/_Sunrise/HairDye/HairDyeSystem.cs
@@ -40,7 +40,7 @@ public sealed class HairDyeSystem : EntitySystem
         args.Verbs.Add(new InteractionVerb()
         {
             Text = (comp.Mode) ? Loc.GetString("hairdye-switch-hair") : Loc.GetString("hairdye-switch-facial"),
-            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/Verbicons/dot.svg.192dpi.png")),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/dot.svg.192dpi.png")),
             Act = () => { comp.Mode = !comp.Mode; },
         });
     }


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Теперь контекстное меню у краски для волос имеет исправленную текстуру в пункте "Переключить на бороду".

## По какой причине
Плашка ERROR вместо текстуры Dot в контекстном меню.

**Changelog**
Несущественно

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые функции
  - Нет изменений, влияющих на функциональность.
- Исправления ошибок
  - Исправлено отображение иконки действия для инструмента окраски волос: корректный путь к ресурсу гарантирует показ верб-иконки, в том числе на дисплеях с высокой плотностью пикселей.
- Прочее
  - Поведение и механики без изменений.
  - Публичные интерфейсы остаются прежними.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->