### PR TITLE
Ребаланс даблы.

### DIFF
--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/weapons/melee/e_sword.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/weapons/melee/e_sword.ftl
@@ -1,0 +1,3 @@
+ent-EnergySwordDoubleBiocode = { ent-EnergySwordDouble }
+    .suffix = SUNRISE
+    .desc = { ent-EnergySwordDouble.desc }

--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/weapons/melee/e_sword.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/weapons/melee/e_sword.ftl
@@ -1,3 +1,3 @@
-ent-EnergySwordDoubleBiocode = { ent-EnergySwordDouble }
+ent-EnergySwordDoubleSunrise = { ent-EnergySwordDouble }
     .suffix = SUNRISE
     .desc = { ent-EnergySwordDouble.desc }

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/biocode.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/biocode.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: EnergySwordDouble
+  parent: EnergySwordDoubleSunrise
   id: EnergySwordDoubleBiocode
   suffix: BIOCODE
   components:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -1,0 +1,93 @@
+- type: entity
+  name: double-bladed energy sword
+  parent: [BaseMeleeWeaponEnergy, BaseSyndicateContraband]
+  id: EnergySwordDoubleSunrise
+  suffix: SUNRISE
+  description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. This can be stored in pockets.
+  components:
+  - type: ItemToggle
+    onUse: false # wielding events control it instead
+    onActivate: false # prevents the weapon from being able to be turned on when it is on the ground
+    soundActivate:
+      path: /Audio/Weapons/ebladeon.ogg
+      params:
+        volume: 3
+    soundDeactivate:
+      path: /Audio/Weapons/ebladeoff.ogg
+      params:
+        volume: 3
+  - type: ItemToggleMeleeWeapon
+    activatedSoundOnSwing:
+      path: /Audio/Weapons/eblademiss.ogg
+      params:
+        volume: 3
+        variation: 0.250
+    activatedDamage:
+      types:
+        Slash: 20
+        Heat: 20
+        Structural: 20
+  - type: ItemToggleActiveSound
+    activeSound:
+      path: /Audio/Weapons/ebladehum.ogg
+      params:
+        volume: 3
+  - type: ComponentToggler
+    components:
+    - type: Sharp
+    - type: DisarmMalus
+      malus: 0.7
+    - type: Execution
+      doAfterDuration: 4.0
+  - type: Wieldable
+    wieldSound: null # esword light sound instead
+  - type: MeleeWeapon
+    wideAnimationRotation: -135
+    autoAttack: true
+    angle: 100
+    damage:
+      types:
+        Blunt: 4.5
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/e_sword_double.rsi
+    layers:
+    - state: e_sword_double
+    - state: e_sword_double_blade
+      color: "#FFFFFF"
+      visible: false
+      shader: unshaded
+      map: [ "blade" ]
+  - type: Item
+    size: Small
+    sprite: Objects/Weapons/Melee/e_sword_double-inhands.rsi
+  - type: Reflect
+    reflectProb: 0.50
+    reflects:
+      - Energy
+  - type: Blocking
+    passiveBlockFraction: 0.4
+    activeBlockFraction: 0.7
+    passiveBlockModifier:
+      coefficients:
+        Blunt: 0.35
+        Slash: 0.35
+        Piercing: 0.5
+        Heat: 0.45
+    activeBlockModifier:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.6
+        Heat: 0.6
+      flatReductions:
+        Heat: 1
+        Piercing: 1
+  - type: FlipOnAttack
+    probability: 0.5
+  - type: Scalpel
+  - type: SurgeryTool
+    successRate: 0.6
+    startSound:
+      path: /Audio/_Sunrise/Medical/Surgery/scalpel1.ogg
+    endSound:
+      path: /Audio/_Sunrise/Medical/Surgery/scalpel2.ogg


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Двойному энергетическому мечу было убрано отражение пуль.
Отражение лазеров: 75% -> 50%.
Удары в секунду: 3 -> 1
Урон: 24 -> 40.
Добавлен компонент щита:
В пассивном состоянии блокирует 40% урона и:
        Blunt: 0.35
        Slash: 0.35
        Piercing: 0.5
        Heat: 0.45
В поднятом состоянии блокирует 70% урона и:
        Blunt: 0.5
        Slash: 0.5
        Piercing: 0.6
        Heat: 0.6

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Дабла полностью игнорирует дальнее оружие, что ну глупо, никакое ближнее оружие не может её перебить, как и дальнее из-за отражения в 75%. Даблу может перебить разве что крапива и подобная залупа, но она если что и эскадрон убить может.

## Технические детали
Пришлось сделать энергетический меч санрайза, потому что дабла визардов парент для некоторых вещей.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: banumbas
- remove: Отражение пуль двойному энергетическому мечу.
- tweak: Отражение лазеров двойному энергетическому мечу: 75% -> 50%.
- tweak: Удары в секунду двойному энергетическому мечу: 3 -> 1
- tweak: Урон двойному энергетическому мечу: 24 -> 40.
- add: Двойной энергетический меч теперь работает как бесконечный щит.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Новые возможности
  * Добавлен двулезвийный энергетический меч (EnergySwordDoubleSunrise, SUNRISE): высокий урон, автоатака, широкий угол взмаха, отражение 50%, пассив/актив-блоки, переключаемое состояние со звуками, визуальные эффекты лезвия, flip on attack, встроенный скальпель с шансом успеха.
  * Добавлена локализация ru-RU для нового меча (alias ent-EnergySwordDoubleSunrise).
* Chore
  * Обновлена родительская ссылка для EnergySwordDoubleBiocode на EnergySwordDoubleSunrise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->