### PR TITLE
carrying system fix

### DIFF
--- a/Content.Shared/_Sunrise/Carrying/SharedCarryingSystem.cs
+++ b/Content.Shared/_Sunrise/Carrying/SharedCarryingSystem.cs
@@ -277,6 +277,10 @@ public sealed class SharedCarryingSystem : EntitySystem
 
     private void Carry(EntityUid carrier, EntityUid carried, CarriableComponent component)
     {
+        if (TryComp<BeingCarriedComponent>(carrier, out var beingCarried))
+        {
+            DropCarried(beingCarried.Carrier, carrier);
+        }
         if (TryComp<PullableComponent>(carried, out var pullable))
             _pullingSystem.TryStopPull(carried, pullable, carrier);
 


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? --> Принудить поднятого игрока отпускать поднятое им существо

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. --> /issues/3126 
Матрёшка из десятка игроков выглядит нелогично и, в теории, может абузиться.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

https://github.com/user-attachments/assets/5a70d01f-f5f6-4e26-b744-45e3344d5a41

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: selnny
- fix: поднятый вами игрок больше не сможет удержаться на ваших руках, если вас поднимут.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Исправления ошибок
  - Перед началом переноса теперь выполняется проверка: если персонаж уже несётся, он автоматически освобождается, после чего перенос начинается корректно.
  - Исключены конфликтные и «вложенные» состояния переноса, снижены случаи застреваний и потери управления.
  - Улучшена согласованность состояний персонажей при начале и остановке переноса, что повышает стабильность взаимодействий и предсказуемость поведения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->