### PR TITLE
Главы что могут стать антагами вновь не имеют МЩ

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -32,7 +32,7 @@
   - Cryogenics
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, TrackingImplant, DeathRattleImplantBlueShield ]
+    implants: [ TrackingImplant, DeathRattleImplantBlueShield ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
@@ -53,7 +53,7 @@
 - type: chameleonOutfit
   id: QuartermasterChameleonOutfit
   job: Quartermaster
-  hasMindShield: true
+  hasMindShield: false #Sunrise-Edit
   equipment:
     head: ClothingHeadHatQMsoft
     eyes: ClothingEyesGlassesSunglasses

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -31,7 +31,7 @@
   - Cryogenics
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, TrackingImplant, DeathRattleImplantBlueShield ]
+    implants: [ TrackingImplant, DeathRattleImplantBlueShield ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
@@ -54,7 +54,7 @@
 - type: chameleonOutfit
   id: ChiefEngineerChameleonOutfit
   job: ChiefEngineer
-  hasMindShield: true
+  hasMindShield: false #Sunrise-Edit
   equipment:
     head: ClothingHeadHatBeretEngineering
     mask: ClothingMaskBreath

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -32,7 +32,7 @@
   - Cryogenics
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, TrackingImplant, DeathRattleImplantBlueShield ]
+    implants: [ TrackingImplant, DeathRattleImplantBlueShield ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
@@ -53,7 +53,7 @@
 - type: chameleonOutfit
   id: ChiefMedicalOfficerChameleonOutfit
   job: ChiefMedicalOfficer
-  hasMindShield: true
+  hasMindShield: false #Sunrise-Edit
   equipment:
     head: ClothingHeadHatBeretCmo
     eyes: ClothingEyesHudMedical

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -27,7 +27,7 @@
   - ResearchConsoleAccess # Sunrise-Edit
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, TrackingImplant, DeathRattleImplantBlueShield ]
+    implants: [ TrackingImplant, DeathRattleImplantBlueShield ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
@@ -49,7 +49,7 @@
 - type: chameleonOutfit
   id: ResearchDirectorChameleonOutfit
   job: ResearchDirector
-  hasMindShield: true
+  hasMindShield: false #Sunrise-Edit
   equipment:
     head: ClothingHeadHatBeretRND
     eyes: ClothingEyesGlasses


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Главы что могут стать предателями, ревой и тд. теперь не имеют МЩ

## По какой причине
Бред что революционер имеет МЩ

## Медиа(Видео/Скриншоты)

<img width="675" height="236" alt="Снимок экрана (4264)" src="https://github.com/user-attachments/assets/f2996c69-6248-43d8-a4a8-251527f68d70" />

**Changelog**
:cl: Kinar_7
- fix: Теперь главы что могут стать антагами вновь не имеют МЩ



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - Раса Вокс теперь может занимать роль Квартирмейстера.

- Изменения баланса
  - С ролей Квартирмейстер, Главный инженер, Главный врач и Директор исследований убрана защита разума, что влияет на взаимодействие с соответствующими механиками контроля и имплантами.
  - Хамелеон-наряды этих ролей больше не помечаются как имеющие защиту разума.
  - Баланс взаимодействий стал более единообразным.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->