### PR TITLE
Удаление тайлов топором

### DIFF
--- a/Resources/Locale/en-US/_prototypes/_sunrise/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/_prototypes/_sunrise/tools/tool-qualities.ftl
@@ -1,0 +1,2 @@
+tool-quality-axing-name = Axing
+tool-quality-axing-tool-name = Fireaxe

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -42,6 +42,7 @@
   - type: Tool
     qualities:
       - Prying
+      - Axing # Sunrise-Add
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -4,6 +4,7 @@
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Sunrise-Add
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -20,6 +21,7 @@
   - 1.0
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Sunrise-Add
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -31,6 +33,7 @@
   sprite: /Textures/Tiles/Asteroid/asteroid_plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Sunrise-Add
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -42,6 +45,7 @@
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Sunrise-Add
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -53,6 +57,7 @@
   sprite: /Textures/Tiles/snow_plating.png #Not in the snow planet RSI because it doesn't have any metadata. Should probably be moved to its own folder later.
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Sunrise-Add
   footstepSounds:
     collection: FootstepPlating
   friction: 0.75 #a little less then actual snow

--- a/Resources/Prototypes/tool_qualities.yml
+++ b/Resources/Prototypes/tool_qualities.yml
@@ -82,3 +82,12 @@
   toolName: tool-quality-fine-screwing-tool-name
   spawn: ThinTippedScrewdriver
   icon: { sprite: Objects/Tools/screwdriver.rsi, state: screwdriver-map }
+
+# Sunrise-Start
+- type: tool
+  id: Axing
+  name: tool-quality-axing-name
+  toolName: tool-quality-axing-tool-name
+  spawn: FireAxe
+  icon: { sprite: Objects/Weapons/Melee/fireaxe.rsi, state: icon }
+# Sunrise-End


### PR DESCRIPTION
Теперь топор может снимать покрытия. Порт https://github.com/space-wizards/space-station-14/pull/ 28845

https://github.com/user-attachments/assets/408dbf96-5a43-4292-bd42-8d3892ed2332



**Changelog**

:cl: F1di
- tweak: Пожарным топором можно убирать покрытия.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Новые возможности
  * Добавлен новый класс качества инструмента «Рубка».
  * Огнетопор теперь поддерживает качество «Рубка».
  * Разбор покрытий/плит с помощью «Рубки» доступен для обычных, повреждённых, астероидных, латунных и снежных вариантов.

* Локализация
  * Добавлены локализованные названия для качества «Рубка» и соответствующего инструмента.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->