### PR TITLE
Холодильник не пропускает газы

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
@@ -117,6 +117,7 @@
       collection: MetalThud
   - type: ExplosionResistance
     damageCoefficient: 0.1
+  - type: Airtight # Sunrise-Add
 
 - type: entity
   parent: SmartFridge


### PR DESCRIPTION
Холодильник больше не пропускает атмос, исправлена главная боль моя дырка задница у мапперов
**Changelog**

:cl: F1di
- tweak: Холодильники больше не пропускают газы.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - Смарт-холодильник получает поведение герметичности после получения урона, снижая риск утечки атмосферы (включая последствия взрывов).
- Исправления ошибок
  - Улучшена сохранность атмосферы вокруг смарт-холодильника после повреждений за счет добавления пост-уронной герметичности.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->