### PR TITLE
Увеличил количество символов в новостных статьях

### DIFF
--- a/Content.Shared/MassMedia/Systems/SharedNewsSystem.cs
+++ b/Content.Shared/MassMedia/Systems/SharedNewsSystem.cs
@@ -4,8 +4,8 @@ namespace Content.Shared.MassMedia.Systems;
 
 public abstract class SharedNewsSystem : EntitySystem
 {
-    public const int MaxTitleLength = 40; #Sunrise_Edit
-    public const int MaxContentLength = 8192; #Sunrise_Edit
+    public const int MaxTitleLength = 40; //Sunrise_Edit
+    public const int MaxContentLength = 8192; //Sunrise_Edit
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
## Кратное описание
Увеличил предел заголовка с 25 до 40, а предел символов в статье с 2048 до 8192

## По какой причине
Игроки которые реально играют за репортера жаловались что даже на бумаге можно написать больше символов чем на консоли

## Медиа(Видео/Скриншоты)


**Changelog**

:cl: Kinar_7

- tweak: Увеличил предел символов в новостных статьях


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Увеличены лимиты для публикации новостей: максимальная длина заголовка — до 40 символов, текста — до 8192 символов.
  - Позволяет создавать более содержательные и развернутые публикации без изменения интерфейса или поведения системы; существующие публикации и рабочие процессы сохраняются.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->