### PR TITLE
Возможность настроить количество окон инвентаря

### DIFF
--- a/Content.Client/Options/UI/Tabs/ExtraTab.xaml
+++ b/Content.Client/Options/UI/Tabs/ExtraTab.xaml
@@ -42,6 +42,10 @@
                 <CheckBox Name="ChatIconsEnableCheckBox" Text="{Loc 'ui-options-chat-icons-enable'}" />
                 <CheckBox Name="ChatPointingVisualsEnableCheckBox" Text="{Loc 'ui-options-chat-pointing-visuals-enable'}" />
 
+                <!-- Inventory -->
+                <Label Text="{Loc 'ui-options-sunrise-general-inventory'}" StyleClasses="LabelKeyText"/>
+                <ui:OptionSlider Name="StorageLimitSlider" Title="{Loc 'ui-options-storage-limit'}" />
+
             </BoxContainer>
         </ScrollContainer>
         <ui:OptionsTabControlRow Name="Control" Access="Public" />

--- a/Content.Client/Options/UI/Tabs/ExtraTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/ExtraTab.xaml.cs
@@ -1,5 +1,6 @@
 using Content.Client.Audio;
 using Content.Server.GameTicking.Prototypes;
+using Content.Shared.CCVar;
 using Content.Shared._Sunrise.Lobby;
 using Content.Shared._Sunrise.SunriseCCVars;
 using Content.Shared.GameTicking;
@@ -31,6 +32,12 @@ public sealed partial class ExtraTab : Control
             SunriseCCVars.TTSRadioVolume,
             SliderTtsRadio,
             scale: ContentAudioSystem.TtsMultiplier);
+
+        Control.AddOptionSlider(
+            CCVars.StorageLimit,
+            StorageLimitSlider,
+            (int)StorageLimitSlider.Slider.MinValue,
+            (int)StorageLimitSlider.Slider.MaxValue);
 
         Control.AddOptionCheckBox(SunriseCCVars.TTSClientEnabled, TtsClientCheckBox);
         Control.AddOptionCheckBox(SunriseCCVars.TTSClientQueueEnabled, TtsClientCheckBoxQueue);

--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -63,7 +63,7 @@ public sealed partial class CCVars
     /// Recommended that you utilise this in conjunction with <see cref="StaticStorageUI"/>
     /// </summary>
     public static readonly CVarDef<int> StorageLimit =
-        CVarDef.Create("control.storage_limit", 1, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("control.storage_limit", 1, CVar.CLIENTONLY | CVar.ARCHIVE); // Sunrise-Edit
 
     /// <summary>
     /// Whether or not storage can be opened recursively.

--- a/Resources/Locale/ru-RU/_strings/_sunrise/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/escape-menu/ui/options-menu.ftl
@@ -34,3 +34,5 @@ ui-options-trace-tooltip =
 ui-options-tts-enabled = ТТС интеграция
 ui-options-tts-queue = Использовать очередь для TTS рации?
 ui-options-tts-radio-ghost-enabled = ТТС рации в призраке
+ui-options-sunrise-general-inventory = Инвентарь
+ui-options-storage-limit = Сколько окон хранилища может быть открыто одновременно.


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Возможность настроить количество окон инвентаря

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Хз прост)

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: banumbas
- add: Теперь можно настроить возможность открытия больше одного окна инвентаря в настройках, вкладка "экстра".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Добавлен ползунок "Предел хранилища" в раздел графики параметров игры. Позволяет регулировать максимальное количество предметов в инвентаре.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->