### PR TITLE
Баффнул ПАКМЕН

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -161,8 +161,8 @@
       maxTargetPower: 30000
       targetPower: 30000
       optimalPower: 30000
-      # 15 minutes at max output
-      optimalBurnRate: 0.0333333
+      # 45 minutes at max output
+      optimalBurnRate: 0.0111111 # Sunrise-Edit
       # a decent curve that goes up to about an hour at 5 kW.
       fuelEfficiencyConstant: 0.75
     - type: SolidFuelGeneratorAdapter
@@ -222,8 +222,8 @@
       maxTargetPower: 50000
       targetPower: 50000
       optimalPower: 50000
-      # 30 minutes at full power
-      optimalBurnRate: 0.016666666
+      # 60 minutes at full power
+      optimalBurnRate: 0.008333333 # Sunrise-Edit
       # Barely save any fuel from reducing power output
       fuelEfficiencyConstant: 0.1
     - type: SolidFuelGeneratorAdapter


### PR DESCRIPTION
## Кратное описание
ПАКМЕН вместо 15 минут, будет работать 45м
СУПЕРПАКМЕН вместо 30, будет работать 60м

## По какой причине
Эти портативные генераторы были невероятно ужасными. Особенно если использовать их на шаттлах. Сейчас хотя бы какой-нибудь смысл от них будет.

## Медиа(Видео/Скриншоты)

<img width="392" height="259" alt="Снимок экрана (4651)" src="https://github.com/user-attachments/assets/e49a9b66-6cb4-41ac-96a2-09fcd20938f6" />
<img width="445" height="256" alt="Снимок экрана (4652)" src="https://github.com/user-attachments/assets/caa2a531-dff3-49eb-b2b9-2b765f9c9991" />

**Changelog**
:cl: Kinar_7
- tweak: Увеличил время работы ПАКМЕН и СУПЕРПАКМЕН. Пакмен 15 > 45. Суперпакмен 30 > 60




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления

* **Исправления**
  * Улучшена производительность портативных генераторов. Время работы Pacman при максимальной мощности увеличено с 15 до 45 минут. Время работы Super Pacman увеличено с 30 до 60 минут при полной нагрузке.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->