### PR TITLE
Телепортер Синдиката (Fix)

### DIFF
--- a/Content.Server/_Sunrise/SyndicateTeleporter/SyndicateTeleporterSystem.cs
+++ b/Content.Server/_Sunrise/SyndicateTeleporter/SyndicateTeleporterSystem.cs
@@ -110,31 +110,20 @@ public sealed class SyndicateTeleporterSystem : EntitySystem
         if (tile is null || _turf.IsTileBlocked(tile.Value, CollisionGroup.Impassable))
             return false;
 
-        var currAabb = _physics.GetWorldAABB(user);
-        if (currAabb.Size == Vector2.Zero)
-            return true;
+        var bodies = _physics.GetEntitiesIntersectingBody(user, (int)CollisionGroup.Impassable);
 
-        var mapCoords = _transform.ToMapCoordinates(coords);
-        var half = currAabb.Size / 2f;
-        var center = mapCoords.Position;
+        foreach (var body in bodies)
+        {
+            if (body == user)
+                continue;
 
-        var targetAabb = new Box2(
-            center.X - half.X,
-            center.Y - half.Y,
-            center.X + half.X,
-            center.Y + half.Y
-        );
+            if (!Transform(body).Anchored)
+                continue;
 
-        if (!_physics.TryCollideRect(targetAabb, mapCoords.MapId))
-            return true;
+            return false;
+        }
 
-        static bool Overlaps(Box2 a, Box2 b) =>
-            a.Left < b.Right && a.Right > b.Left && a.Bottom < b.Top && a.Top > b.Bottom;
-
-        if (Overlaps(targetAabb, currAabb))
-            return true;
-
-        return false;
+        return true;
     }
 
     private bool TryFindSafeTile(EntityUid user, EntityCoordinates origin, out EntityCoordinates? result)

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Devices/Syndicate_Gadgets/syndicate_teleporter.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Devices/Syndicate_Gadgets/syndicate_teleporter.yml
@@ -14,7 +14,7 @@
     teleportationValue: 4
     damageOnBlocked:
       types:
-        Cellular: 25
+        Cellular: 10
   - type: UseDelay
     delay: 0.5
   - type: LimitedCharges


### PR DESCRIPTION
## Кратное описание
При использование телепортера синдиката была проблема с тем что он работал неправильно если на тайле есть какие-то лужи то срабатывала безопасная телепортация которая тепало на ближайщий безопасный тайл и наносила игроку урон.

Теперь если точка телепорта свободна но при этом там лужи или кровь - будет срабатывать нормальный телепорт и пешка не будет получать урон

Уменьшил урон при неудачной телепоратации с 25 генетических до 10 генетических

**Changelog**


:cl: Orvex07
- tweak: Снижение урона при неудачной телепоратации: 25 -> 10
- fix: При телепортации на лужи более не будет наносится урон


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления

* **Балансировка**
  * Снижена урона синдикального телепортера при блокировке: урон уменьшен с 25 до 10 единиц.

* **Улучшения**
  * Усовершенствована система определения доступности мест для телепортации. Повышена точность проверки целевых локаций перед телепортированием.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->