### PR TITLE
Мехи: Озвучка

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -95,10 +95,12 @@ public sealed partial class MechSystem : SharedMechSystem
         #endregion
     }
 
+    // Sunrise-Start
     private void OnMechSay(EntityUid uid, MechComponent component, MechSayEvent args)
     {
-        _chatSystem.TrySendInGameICMessage(uid, Loc.GetString(args.Message), InGameICChatType.Speak, ChatTransmitRange.Normal);
+        _chatSystem.TrySendInGameICMessage(uid, Loc.GetString(args.Message), InGameICChatType.Whisper, ChatTransmitRange.Normal);
     }
+    // Sunrise-End
 
     private void OnMechCanMoveEvent(EntityUid uid, MechComponent component, UpdateCanMoveEvent args)
     {
@@ -317,6 +319,7 @@ public sealed partial class MechSystem : SharedMechSystem
         }
     }
 
+    // Sunrise-Start
     private void SayCritMessage(EntityUid uid, MechComponent component, DamageableComponent damage, bool damageIncreased)
     {
         if (!damageIncreased)
@@ -345,11 +348,21 @@ public sealed partial class MechSystem : SharedMechSystem
                     _ => string.Empty
                 };
 
-                if (!string.IsNullOrEmpty(message))
-                    _chatSystem.TrySendInGameICMessage(uid, Loc.GetString(message), InGameICChatType.Speak, ChatTransmitRange.Normal);
+                if (string.IsNullOrEmpty(message))
+                    return;
+
+                var chatType = newState switch
+                {
+                    MechHealthState.Critical => InGameICChatType.Speak,
+                    MechHealthState.Damaged => InGameICChatType.Whisper,
+                    _ => InGameICChatType.Whisper
+                };
+
+                _chatSystem.TrySendInGameICMessage(uid, Loc.GetString(message), chatType, ChatTransmitRange.Normal);
             }
         }
     }
+    // Sunrise-End
 
     private void ToggleMechUi(EntityUid uid, MechComponent? component = null, EntityUid? user = null)
     {


### PR DESCRIPTION
## Кратное описание
Мехи будут озвучивать действия и статус шёпотом за исключением критического статуса (меньше 5 % прочности)

**Changelog**

:cl: Orvex07
- tweak: некоторые сообщения мехов будут воспроизводится в качестве шёпота



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Изменена логика общения механизма: сообщения теперь зависят от состояния здоровья. При критическом состоянии механизм кричит, при повреждении — шепчет, в остальных случаях — также использует шепот.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->