### PR TITLE
FIX Игральные карты

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Fun/poker_cards.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Fun/poker_cards.yml
@@ -99,7 +99,7 @@
   components:
   - type: SpawnItemsOnUse
     items:
-    - id: PokerCardTwoClub
+    - id: PokerCardThreeClub
   - type: Sprite
     sprite: _Sunrise/Objects/Fun/Cards/poker_cards.rsi
     scale: 0.5,0.5

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Fun/poker_cards_classic.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Fun/poker_cards_classic.yml
@@ -99,7 +99,7 @@
   components:
   - type: SpawnItemsOnUse
     items:
-    - id: PokerCardClassicTwoClub
+    - id: PokerCardClassicThreeClub
   - type: Sprite
     sprite: _Sunrise/Objects/Fun/Cards/poker_cards_classic.rsi
     scale: 0.5,0.5


### PR DESCRIPTION
## Кратное описание
Починка PR https://github.com/space-sunrise/sunrise-station/pull/674 
В колоде карт присутствовало пять двоек и три тройки

## По какой причине
фикс

## Медиа(Видео/Скриншоты)
Было 
<img width="1294" height="846" alt="image" src="https://github.com/user-attachments/assets/04228183-a585-4ede-a37e-cfa1aba1ad88" />
Стало 
<img width="598" height="532" alt="image" src="https://github.com/user-attachments/assets/49d3e3aa-c916-46ee-9561-00a0d97cda73" />


**Changelog**
:cl: iDesmond
- fix: Колоды карт теперь вновь имеют четыре двойки и четыре тройки
