### PR TITLE
Мини-Доработка: Панели телепорта призрака 

### DIFF
--- a/Content.Server/_Sunrise/Ghost/GhostPanelAntagonistMarkerSystem.cs
+++ b/Content.Server/_Sunrise/Ghost/GhostPanelAntagonistMarkerSystem.cs
@@ -19,17 +19,16 @@ public sealed class GhostPanelAntagonistMarkerSystem : EntitySystem
         if (!TryComp<MobStateComponent>(ent, out var mobState))
             return;
 
-        var enabled = mobState.CurrentState != MobState.Dead;
-        if (ent.Comp.Enabled == enabled)
-            return;
-
-        ent.Comp.Enabled = enabled;
-        Dirty(ent, ent.Comp);
+        UpdateEnabled(ent, mobState.CurrentState != MobState.Dead);
     }
 
     private void OnMobStateChanged(Entity<GhostPanelAntagonistMarkerComponent> ent, ref MobStateChangedEvent args)
     {
-        var enabled = args.NewMobState != MobState.Dead;
+        UpdateEnabled(ent, args.NewMobState != MobState.Dead);
+    }
+
+    private void UpdateEnabled(Entity<GhostPanelAntagonistMarkerComponent> ent, bool enabled)
+    {
         if (ent.Comp.Enabled == enabled)
             return;
 

--- a/Content.Server/_Sunrise/Ghost/GhostSystem.GhostPanelSpecific.cs
+++ b/Content.Server/_Sunrise/Ghost/GhostSystem.GhostPanelSpecific.cs
@@ -109,15 +109,12 @@ public sealed partial class GhostSystem
             if (!component.Enabled)
                 continue;
 
-            var isDead = _mobState.IsDead(uid);
-
             var warp = new GhostWarpGlobalAntagonist(
                 GetNetEntity(uid),
                 meta.EntityName,
                 component.Name,
                 component.Description,
-                component.Priority,
-                isDead
+                component.Priority
             );
 
             yield return warp;

--- a/Content.Shared/_Sunrise/Ghost/SharedGhostSystem.GhostPanelSpecific.cs
+++ b/Content.Shared/_Sunrise/Ghost/SharedGhostSystem.GhostPanelSpecific.cs
@@ -50,15 +50,13 @@ public abstract partial class SharedGhostSystem
     /// <param name="AntagonistName">Название антагониста</param>
     /// <param name="AntagonistDescription">Описание антагониста</param>
     /// <param name="Priority">Приоритет отображения антагониста</param>
-    /// <param name="IsDead">Мертв ли антагонист?</param>
     [Serializable, NetSerializable]
     public record struct GhostWarpGlobalAntagonist(
         NetEntity Entity,
         string Name,
         string AntagonistName,
         string AntagonistDescription,
-        int Priority,
-        bool IsDead) : INamedGhostWarp
+        int Priority) : INamedGhostWarp
     {
         public readonly NetEntity Entity = Entity;
 
@@ -69,8 +67,6 @@ public abstract partial class SharedGhostSystem
         public readonly string AntagonistDescription = AntagonistDescription;
 
         public readonly int Priority = Priority;
-
-        public readonly bool IsDead = IsDead;
 
     }
 


### PR DESCRIPTION
## Кратное описание
Доработка точек телепорта призрака, мертвые антагонисты пропадают с листа точек телепорта призраков. 

## По какой причине
Мертвые антагонисты не пропадают с панели телепорта призрака, из-за чего может быть лист из более чем 300 мертвых зомби.

[ишшуй](https://github.com/space-sunrise/sunrise-station/issues/3369)

:cl: Orvex07
- add: Мертвые антагонисты пропадают с панели телепортации призрака. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Реализована автоматическая синхронизация состояния антагонистов в панели привидений с их текущим статусом жизни в реальном времени.

* **Исправления ошибок**
  * Исправлена обработка отключенных компонентов для предотвращения ошибок при отображении информации о противниках.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->