### PR TITLE
Фикс отсутствия КПК у ролей отделов

### DIFF
--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/devices/pda.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/devices/pda.ftl
@@ -70,3 +70,5 @@ ent-PilotPDA = КПК пилота
     .desc = Имеет защиту от космической радиации.
 ent-CommaidPDA = КПК горничной командования
     .desc = { ent-BasePDA.desc }
+ent-SecuritySergeantPDA = КПК сержанта СБ
+    .desc = Всё ещё работает. В отличие от владельца, не кричит на вас.

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -607,7 +607,7 @@
     scale: 1.05, 1.05
     layers:
     - state: bal-127
-    - state: mag-0
+    - state: mag-13
       map: ["enum.GunVisualLayers.Mag"]
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -164,3 +164,19 @@
   id: MedicalEyePatchHud
   equipment:
     eyes: ClothingEyesEyepatchHudMedical
+
+#sunrise-start
+# ID
+- type: loadout
+  id: MedicalPDA
+  equipment:
+    id: MedicalPDA
+
+- type: loadout
+  id: SeniorPhysicianPDA
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysician
+  equipment:
+    id: SeniorPhysicianPDA
+#sunrise-end

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -166,7 +166,7 @@
   - !type:GroupLoadoutEffect
     proto: SeniorOfficer
   equipment:
-    id: SeniorOfficerPDA
+    id: SecuritySergeantPDA #SeniorOfficerPDA Sunrise-edit
 
 # Misc
 - type: loadout

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1680,3 +1680,33 @@
   hidden: true
   loadouts:
   - LoadoutSpeciesBreathToolSecurity
+
+# Sunrise-start
+- type: loadoutGroup
+  id: StationEngineerID
+  name: loadout-group-station-engineer-id
+  loadouts:
+  - StationEngineerPDA
+  - SeniorEngineerPDA
+
+- type: loadoutGroup
+  id: ScientistPDA
+  name: loadout-group-scientist-id
+  loadouts:
+  - ScientistPDA
+  - SeniorResearcherPDA
+
+- type: loadoutGroup
+  id: SecurityPDA
+  name: loadout-group-security-id
+  loadouts:
+  - SecurityPDA
+  - SeniorOfficerPDA
+
+- type: loadoutGroup
+  id: MedicalDoctorPDA
+  name: loadout-group-medical-doctor-id
+  loadouts:
+  - MedicalPDA
+  - SeniorOfficerPDA
+# Sunrise-edn

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -435,7 +435,7 @@
   - StationSunriseEngineerNeck
    # Sunrise-end
   - StationEngineerShoes
-  #- StationEngineerID
+  - StationEngineerID
   - SurvivalExtended
   - Trinkets
   - GroupSpeciesBreathTool
@@ -507,7 +507,7 @@
   - ScientistOuterClothing
   - ScientistGloves
   - ScientistShoes
-  #- ScientistPDA
+  - ScientistPDA
   - Glasses
   - Survival
   - Trinkets
@@ -586,7 +586,7 @@
   - SecurityBackpack
   - SecurityOuterClothing
   - SecurityShoes
-  #- SecurityPDA
+  - SecurityPDA
   - SecurityBelt
   - SurvivalSecurity
   - Trinkets
@@ -681,7 +681,7 @@
   - SunriseMedicalDoctorNeck
   # Sunrise-end
   - MedicalShoes
-  #- MedicalDoctorPDA
+  - MedicalDoctorPDA
   - MedicalEyewear
   - SurvivalMedical
   - Trinkets

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -25,7 +25,7 @@
     EnergyMagnumStealObjective: 0.5
     # Sunrise-Start
     PlutoniumCoreStealObjective: 0.5
-    #MultiphaseEnergygunStealObjective: 1 # Sunrise-Edit: ОСЩ больше не появляется на станции
+    MultiphaseEnergygunStealObjective: 1
     CMOAdvancedDefibrillatorStealObjective: 1
     HandheldFaxStealObjective: 1
     # Sunrise-End

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Devices/pda.yml
@@ -702,3 +702,8 @@
     sprite: _Sunrise/Objects/Devices/pda.rsi
     state: pda-commaid
 
+- type: entity
+  parent: SeniorOfficerPDA
+  id: SecuritySergeantPDA
+  name: security sergeant PDA
+  description: Still functional. Unlike its owner, it does not shout at you.


### PR DESCRIPTION
Introduces SecuritySergeantPDA entity and Russian localization, adds MedicalPDA and SeniorPhysicianPDA to medical doctor loadouts, and enables PDA loadout groups for Station Engineer, Scientist, Security, and Medical Doctor roles. Also updates shuttle cannon magazine state and objective group for MultiphaseEnergygunStealObjective.

<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Оффы добавили лодауты кпк, у нас удалили от чего удалились в целом КПК у базовых ролей отделов

Возвращена цель на Мультифаз, так как ОСЩ снова ходит по этой бренной земле
**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- add: Добавлена цель предателям на пистолет X-01.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления

* **Новые возможности**
  * Добавлены новые PDA-устройства: для сержанта безопасности, врача и старшего врача.
  * Добавлены опции выбора PDA/ID для инженеров станции, учёных, сотрудников безопасности и медицинского персонала.
  * Добавлена новая задача для предателей: кража многофазного энергооружия.

* **Обновления**
  * Обновлено визуальное состояние кассеты орудия на шаттле.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->