### PR TITLE
Локаль газовой трубы

### DIFF
--- a/Resources/Locale/ru-RU/construction/recipes/utilities.ftl
+++ b/Resources/Locale/ru-RU/construction/recipes/utilities.ftl
@@ -1,3 +1,4 @@
+construction-recipe-gas-pipe-straight = прямая газовая труба
 construction-recipe-gas-pipe-half = половина газовой трубы
 construction-recipe-gas-pipe-bend = изгиб газовой трубы
 construction-recipe-gas-pipe-t-junction = газопроводный T-образный переходник

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -353,6 +353,7 @@
 
 - type: construction
   id: GasPipeStraight
+  name: construction-recipe-gas-pipe-straight #sunrise-edit fix
   graph: GasPipe
   startNode: start
   targetNode: straight


### PR DESCRIPTION
## Кратное описание
Подправлена локализация прямой газовой трубы, что бы в поиске крафта можно было найти все виды труб разом

## По какой причине
Атмосам приходится постоянно менять слово поиска в меню крафта, что бы выбирать другой тип трубы. Теперь все они имеют общий фрагмент [газ] для поиска

## Медиа(Видео/Скриншоты)
<img width="492" height="634" alt="image" src="https://github.com/user-attachments/assets/f9db098d-292e-41db-b498-82c59bc07615" />


**Changelog**

:cl: iDesmond
- fix:  Подправлена локализация прямой газовой трубы, что бы в поиске крафта можно было найти все виды труб разом



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Локализация**
  * Добавлена поддержка русского языка для рецепта строительства прямой газовой трубы. Игроки в русской локали теперь видят корректное отображение названия конструкции в интерфейсе игры.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->