### PR TITLE
Fix: Chat - Job Icons 

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Input;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Linq;
+using Robust.Client.UserInterface.RichText; // Sunrise-Edit
 using static Robust.Client.UserInterface.Controls.LineEdit;
 
 namespace Content.Client.UserInterface.Systems.Chat.Widgets;
@@ -22,6 +23,21 @@ namespace Content.Client.UserInterface.Systems.Chat.Widgets;
 [Virtual]
 public partial class ChatBox : UIWidget
 {
+    // Sunrise-Start
+    // По умолчаюнию разрешены только RichTextEntry.DefaultTags.
+    // Теги ниже нужны для корректного отображения иконок в чате
+    private static readonly Type[] TagsAllowed =
+    [
+        typeof(BoldItalicTag),
+        typeof(BoldTag),
+        typeof(BulletTag),
+        typeof(ColorTag),
+        typeof(HeadingTag),
+        typeof(ItalicTag),
+        typeof(Client._Sunrise.UserInterface.RichText.RadioIconTag),
+    ];
+    // Sunrise-End
+
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly ILogManager _log = default!;
 
@@ -146,6 +162,7 @@ public partial class ChatBox : UIWidget
         formatted.AddMarkupOrThrow(message);
         formatted.Pop();
         Contents.AddMessage(formatted);
+        Contents.SetMessage(^1, formatted, TagsAllowed); // Sunrise-Edit
     }
 
     public void Focus(ChatSelectChannel? channel = null)

--- a/Content.Client/_Sunrise/UserInterface/Controls/RichTextButton.cs
+++ b/Content.Client/_Sunrise/UserInterface/Controls/RichTextButton.cs
@@ -1,9 +1,17 @@
 ﻿using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Utility;
 
 namespace Content.Client._Sunrise.UserInterface.Controls;
 
 public sealed class RichTextButton : Button
 {
+    private static readonly Type[] TagsAllowed =
+    [
+        typeof(ColorTag),
+        typeof(UserInterface.RichText.TextureTag),
+    ];
+
     public new RichTextLabel Label { get; }
 
     public RichTextButton()
@@ -43,6 +51,10 @@ public sealed class RichTextButton : Button
     public new string Text
     {
         get => Label.Text ?? string.Empty;
-        set => Label.Text = MakeTextReadable(value, ModulateSelfOverride ?? Modulate);
+        set
+        {
+            var markup = MakeTextReadable(value, ModulateSelfOverride ?? Modulate);
+            Label.SetMessage(FormattedMessage.FromMarkupPermissive(markup), TagsAllowed);
+        }
     }
 }

--- a/Content.Client/_Sunrise/UserInterface/Systems/Ghost/Controls/SunriseGhostTargetWindow.Generation.xaml.cs
+++ b/Content.Client/_Sunrise/UserInterface/Systems/Ghost/Controls/SunriseGhostTargetWindow.Generation.xaml.cs
@@ -4,6 +4,8 @@ using Robust.Client.UserInterface.Controls;
 using GhostWarpPlayer = Content.Shared.Ghost.SharedGhostSystem.GhostWarpPlayer;
 using GhostWarpPlace = Content.Shared.Ghost.SharedGhostSystem.GhostWarpPlace;
 using GhostWarpGlobalAntagonist = Content.Shared.Ghost.SharedGhostSystem.GhostWarpGlobalAntagonist;
+using Robust.Shared.Utility;
+
 
 namespace Content.Client._Sunrise.UserInterface.Systems.Ghost.Controls;
 
@@ -115,7 +117,7 @@ public sealed partial class SunriseGhostTargetWindow
             var placeButton = new RichTextButton
             {
                 ModulateSelfOverride = PlaceButtonColor,
-                Text = TruncateWithEllipsis(place.Name, MaxLenghtWithoutIcons),
+                Text = FormattedMessage.EscapeText(TruncateWithEllipsis(place.Name, MaxLenghtWithoutIcons)),
                 TextAlign = Label.AlignMode.Right,
                 HorizontalAlignment = HAlignment.Center,
                 VerticalAlignment = VAlignment.Center,
@@ -167,7 +169,7 @@ public sealed partial class SunriseGhostTargetWindow
                 var playerButton = new RichTextButton
                 {
                     ModulateSelfOverride = AntagonistButtonColor,
-                    Text = TruncateWithEllipsis(antag.Name, MaxLenghtWithoutIcons),
+                    Text = FormattedMessage.EscapeText(TruncateWithEllipsis(antag.Name, MaxLenghtWithoutIcons)),
                     TextAlign = Label.AlignMode.Right,
                     HorizontalAlignment = HAlignment.Center,
                     VerticalAlignment = VAlignment.Center,

--- a/Content.Client/_Sunrise/UserInterface/Systems/Ghost/Controls/SunriseGhostTargetWindow.Helpers.xaml.cs
+++ b/Content.Client/_Sunrise/UserInterface/Systems/Ghost/Controls/SunriseGhostTargetWindow.Helpers.xaml.cs
@@ -3,6 +3,8 @@ using Content.Shared.Ghost;
 using Content.Shared.Roles;
 using GhostWarpPlayer = Content.Shared.Ghost.SharedGhostSystem.GhostWarpPlayer;
 using GhostWarpGlobalAntagonist = Content.Shared.Ghost.SharedGhostSystem.GhostWarpGlobalAntagonist;
+using Robust.Shared.Utility;
+
 
 namespace Content.Client._Sunrise.UserInterface.Systems.Ghost.Controls;
 
@@ -62,7 +64,7 @@ public sealed partial class SunriseGhostTargetWindow
     /// <returns>Сгенерированное название с иконкой</returns>
     private string GeneratePlayerLabel(GhostWarpPlayer warp)
     {
-        var playerName = TruncateWithEllipsis(warp.Name, MaxLenght);
+        var playerName = FormattedMessage.EscapeText(TruncateWithEllipsis(warp.Name, MaxLenght));
         var jobIcon = _chatIcons.GetJobIcon(warp.JobId, 3);
 
         return $"{jobIcon} {playerName}";

--- a/Resources/Locale/en-US/_strings/_sunrise/tags/entity_texture.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/tags/entity_texture.ftl
@@ -1,0 +1,2 @@
+ent-texture-tag-short = [enttex id="{ $id }"]
+ent-texture-tag = [enttex id="{ $id }" scale={ $scale }]

--- a/Resources/Locale/en-US/_strings/_sunrise/tags/radio_icon.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/tags/radio_icon.ftl
@@ -1,0 +1,2 @@
+radio-icon-tag-short = [radicon path="{ $path }" text="{ $text }" color="{ $color }"]
+radio-icon-tag = [radicon path="{ $path }" scale={ $scale } text="{ $text }" color="{ $color }"]

--- a/Resources/Locale/en-US/_strings/_sunrise/tags/texture.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/tags/texture.ftl
@@ -1,0 +1,2 @@
+texture-tag-short = [tex path="{ $path }"]
+texture-tag = [tex path="{ $path }" scale={ $scale }]


### PR DESCRIPTION

<img width="428" height="33" alt="изображение" src="https://github.com/user-attachments/assets/87a8d775-04b5-4afa-9ddd-a1c60eb381c6" />

Починил иконки в радиоканале и в панели призрака
Причина была в вайтлисте тегов. По умолчанию разрашется только `RichTextEntry.DefaultTags` по новой системе оффов.
Добавил так же добавил  `FormattedMessage.EscapeText` были проблемы с валидными тегами

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Добавлена поддержка значков в тексте чата с использованием разметки RichText.
  * Добавлена возможность управления прозрачностью окна чата через конфигурацию.
  * Улучшена поддержка форматирования текста в кнопках с использованием разметки.

* **Исправления ошибок**
  * Исправлена безопасность отображения текста в интерфейсе выбора целей.
  * Улучшена обработка усечённых названий для корректного отображения.

* **Локализация**
  * Добавлены строки локализации для текстур сущностей и значков радио.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->