### PR TITLE
Стаминарезисты тренча ГСБ

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -100,7 +100,7 @@
         Caustic: 0.75 # not the full 90% from ss13 because of the head
   - type: ExplosionResistance
     damageCoefficient: 0.9
-      - type: StaminaResistance # Sunrise-Add
+  - type: StaminaResistance # Sunrise-Add
     damageCoefficient: 0.9 # Sunrise-Add
 
 - type: entity


### PR DESCRIPTION

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Добавление стаминарезистов тренчу ГСБ

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Для баланса вселенной

**Changelog**
:cl: obezyana
- add: Добавлены стаминарезисты тренчу ГСБ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Броня теперь включает полную защиту от урона выносливости с коэффициентом снижения 0.9. Это значительное расширение защитных свойств брони обеспечивает персонажам дополнительный и важный уровень защиты против атак, основанных на выносливости. Улучшение делает броню существенно более универсальной и полезной в боевых ситуациях, позволяя игрокам эффективнее противостоять разнообразным типам атак в игре.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->