### PR TITLE
ПТ | фикс распределения слотов ролей при присоединении

### DIFF
--- a/Content.Server/_Sunrise/Roles/RelativeJobsCountSystem.cs
+++ b/Content.Server/_Sunrise/Roles/RelativeJobsCountSystem.cs
@@ -116,6 +116,10 @@ public sealed class RelativeJobsCountSystem : EntitySystem
             return;
         }
 
+        // Если TotalMaxCount равен -1 (без ограничений), не вычитаем из него
+        if (station.Comp.TotalMaxCount[settings.TargetJob] == -1)
+            return;
+
         station.Comp.TotalMaxCount[settings.TargetJob] -= value;
     }
 


### PR DESCRIPTION
## По какой причине

Без этого фикса есть проблема, что если например заходишь за роль НПТ, дается +2 слота к роли зека, ещё раз заходишь за любую роль охраны, и вот больше не давало слотов для зеков, хотя должно было...

**Changelog**
:cl: ПТ | KAVALDi
- fix: Исправлено распределение слотов ролей ПТ при присоединении

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Исправлена обработка неограниченных слотов в системе управления должностями — теперь система корректно работает с неограниченными значениями и предотвращает некорректное снижение счетчика в соответствующих сценариях.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->