### PR TITLE
ПТ | добавил чуть встроенных программ в ПДА (инженер, ученый, доктор, разнорабочий)

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Devices/pda.yml
@@ -225,6 +225,15 @@
     accentVColor: "#cc5200"
   - type: Icon
     state: pda-space-prison-engineer
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+      - AstroNavCartridge
+      - NetProbeCartridge
 
 - type: entity
   parent: SecurityMetusPDA
@@ -244,6 +253,14 @@
     accentVColor: "#7a2699"
   - type: Icon
     state: pda-space-prison-scientist
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+      - AstroNavCartridge
 
 - type: entity
   parent: SecurityMetusPDA
@@ -263,6 +280,14 @@
     accentVColor: "#2f6e67"
   - type: Icon
     state: pda-space-prison-doctor
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+      - MedTekCartridge
 
 - type: entity
   parent: SecurityMetusPDA
@@ -301,6 +326,14 @@
     accentVColor: "#4b0100"
   - type: Icon
     state: pda-space-prison-worker
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+      - AstroNavCartridge
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
## Кратное описание
Установил дополнительные проги в ПДА ролей:
- Тюремный инженер
  -  координаты (AstroNavCartridge) и скан. сети приборов (NetProbeCartridge)
- Тюремный учёный
  -  координаты (AstroNavCartridge)
- Тюремный доктор 
  -  медицинский сканер (MedTekCartridge)
- Тюремный разнорабочий 
  -  координаты (AstroNavCartridge)

## По какой причине
Изначально добавил только для доктора по [этому](https://discord.com/channels/1253315855731916821/1457712751198736566/1457863645102080037) сообщению, но после чтот и другим ролям захотелось добавить, чтоб подходило им и делало их более ценными.

**Changelog**
:cl: ПТ | KAVALDi
- add: Добавил дополнительные программы из картриджей для тюремных ролей: инженер, учёный, доктор, разнорабочий

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * КПК различных ролей теперь поставляются с предустановленными картриджами приложений в зависимости от должности.
  * Персонажи получают КПК с набором инструментов, соответствующим их ролям: охранники и офицеры получают средства управления экипажем и логирования, инженеры и учёные — навигационные и диагностические системы, медработники — медицинские приложения. Все КПК включают манифест экипажа, записную книжку и другие полезные программы.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->