### PR TITLE
ПТ | Добавил требование (2 часа за Химика) для открытия роли Тюремный Доктор

### DIFF
--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/PlanetPrison/prison_doctor.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/PlanetPrison/prison_doctor.yml
@@ -7,6 +7,9 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 7200 # 2 hrs
+    - !type:RoleTimeRequirement
+      role: JobChemist
+      time: 7200 #2 hrs
     - !type:DepartmentTimeRequirement
       department: Security
       time: 7200 # 2 hrs


### PR DESCRIPTION
## По какой причине
На всю ПТ только **один** доктор, если он не умеет варить базу - это потеря...
(больше слотов пока не планируется)

**Changelog**
:cl: ПТ | KAVALDi
- add: Добавил требование (2 часа за Химика) для открытия роли Тюремный Доктор

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения игромеханики**
  * Добавлено новое требование для должности тюремного врача: необходимо предварительно отработать на должности химика определённое количество времени перед переходом на эту роль.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->