### PR TITLE
Коробку мензурок в шкаф Бригмедика 

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -109,8 +109,8 @@
     children:
     - id: ClothingEyesGlassesSecurity
     - id: WeaponTaser
-    - id: BoxBeaker
-    - id: BoxVial
+    - id: BoxBeaker # Sunrise-edit
+    - id: BoxVial # Sunrise-edit
     - id: WeaponDisabler
     - id: TrackingImplanter
       amount: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Добавления коробку мензурок и коробку пробирок в шкаф бригмедика.
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Предложка взята со сборки Lust Station (https://discord.com/channels/1253315855731916821/1457682820901376083)
Отсутствие самих мензурок на новых станциях.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="357" height="298" alt="Screenshot_141" src="https://github.com/user-attachments/assets/26b0432b-6bb4-49b9-8ac8-8df911d201ff" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VenZ
- add: Добавлены коробка мензурок и пробирок в шкафчик Бригмедика
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * В пул предметов медицинских шкафчиков добавлены два новых контейнера — BoxBeaker и BoxVial, увеличивая разнообразие и потенциал находок для игроков.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->