### PR TITLE
ПТ | fix ERROR тумана

### DIFF
--- a/Content.Client/Overlays/StencilOverlay.RestrictedRange.cs
+++ b/Content.Client/Overlays/StencilOverlay.RestrictedRange.cs
@@ -52,7 +52,7 @@ public sealed partial class StencilOverlay
         worldHandle.UseShader(_protoManager.Index(StencilMask).Instance());
         worldHandle.DrawTextureRect(res.Blep!.Texture, worldBounds);
         var curTime = _timing.RealTime;
-        var sprite = _sprite.GetFrame(new SpriteSpecifier.Texture(new ResPath("/Textures/Parallaxes/noise.png")), curTime);
+        var sprite = _sprite.GetFrame(new SpriteSpecifier.Texture(new ResPath("/NetTextures/Parallaxes/noise.png")), curTime); // Sunrise-Edit
 
         // Draw the rain
         worldHandle.UseShader(_protoManager.Index(StencilDraw).Instance());


### PR DESCRIPTION
## Кратное описание
Исправил путь к спрайту, который используется для тумана вокруг ПТ (тот самый, что зеков гостами делает)

## По какой причине
- До исправления спрайт тумана был ERROR (выглядело забавно)
- Клиентская консоль спамится ошибками
  - [ERRO] res: Exception while loading resource Robust.Client.ResourceManagement.TextureResource at '/Textures/Parallaxes/noise.png', resorting to fallback.


## Медиа(Видео/Скриншоты)

<details>
  <summary>ERROR туман</summary>
<img width="1150" height="646" alt="изображение" src="https://github.com/user-attachments/assets/b7f92e24-00db-418a-ae49-ccf971239ddc" />
</details>

<details>
  <summary>Фикс тумана</summary>
<img width="1139" height="636" alt="изображение" src="https://github.com/user-attachments/assets/a36a7d20-417a-485e-a5cb-6d5c7ceac278" />
</details>

**Changelog**
:cl: ПТ | KAVALDi
- fix: Исправлен спрайт тумана на ПТ (который зеков гостами делает)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Обновлена внутренняя ссылка на текстурный ресурс для оптимизации загрузки визуальных элементов.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->