### PR TITLE
Fix: AssaultOps Ghost Panel

### DIFF
--- a/Resources/Locale/en-US/_strings/_sunrise/assault-ops/ghost-roles.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/assault-ops/ghost-roles.ftl
@@ -1,0 +1,6 @@
+ghost-role-information-assaultops-commander-name = Diversionary Squad Commander
+ghost-role-information-assaultops-operative-name = Diversionary Squad Member
+ghost-role-information-assaultops-description = You are a member of the Syndicate diversionary squad assigned to the destruction of the station. Your task as an antagonist is to do whatever is necessary to achieve this goal.
+
+assaultops-ghostpanel-commander = COMMANDER
+assaultops-ghostpanel-operative = SQUAD MEMBER

--- a/Resources/Locale/en-US/_strings/_sunrise/assault-ops/preset.ftl
+++ b/Resources/Locale/en-US/_strings/_sunrise/assault-ops/preset.ftl
@@ -1,0 +1,2 @@
+assaultops-title = Diversionary Squad
+assaultops-description = A Syndicate diversionary squad has targeted the station to gain access to NanoTrasen's secret weapon, Icarus.

--- a/Resources/Locale/ru-RU/_strings/_sunrise/assault-ops/ghost-roles.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/assault-ops/ghost-roles.ftl
@@ -1,0 +1,6 @@
+ghost-role-information-assaultops-commander-name = Командир диверсионного отряда
+ghost-role-information-assaultops-operative-name = Член диверсионного отряда
+ghost-role-information-assaultops-description = Вы - член диверсионного отряда Синдиката, назначенный для уничтожения станции. Ваша задача как антагониста - сделать всё необходимое для достижения этой цели.
+
+assaultops-ghostpanel-commander = КОМАНДИР
+assaultops-ghostpanel-operative = ЧЛЕН ОТРЯДА

--- a/Resources/Prototypes/_Sunrise/AssaultOps/ghost_roles.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/ghost_roles.yml
@@ -4,8 +4,8 @@
   id: SpawnPointAssaultOpsCommander
   components:
   - type: GhostRole
-    name: AssaultOps Commander
-    description: You are a syndicate operative assigned to the destruction of the station. Your task as an antagonist is to do whatever is necessary to achieve this goal.
+    name: ghost-role-information-assaultops-commander-name
+    description: ghost-role-information-assaultops-description
     rules: ghost-role-information-rules-default-team-antagonist
     raffle:
       settings: default
@@ -24,8 +24,8 @@
   id: SpawnPointAssaultOpsOperative
   components:
   - type: GhostRole
-    name: AssaultOps Operative
-    description: You are a syndicate operative assigned to the destruction of the station. Your task as an antagonist is to do whatever is necessary to achieve this goal.
+    name: ghost-role-information-assaultops-operative-name
+    description: ghost-role-information-assaultops-description
     rules: ghost-role-information-rules-default-team-antagonist
     raffle:
       settings: default

--- a/Resources/Prototypes/_Sunrise/AssaultOps/roundstart.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/roundstart.yml
@@ -28,6 +28,10 @@
       roleLoadout:
       - RoleSurvivalAssaultOps
       components:
+      - type: GhostPanelAntagonistMarker
+        name: assaultops-title
+        description: assaultops-ghostpanel-commander
+        priority: 85
       - type: AssaultOperative
       - type: NpcFactionMember
         factions:
@@ -48,6 +52,10 @@
       roleLoadout:
       - RoleSurvivalAssaultOps
       components:
+      - type: GhostPanelAntagonistMarker
+        name: assaultops-title
+        description: assaultops-ghostpanel-operative
+        priority: 85
       - type: AssaultOperative
       - type: NpcFactionMember
         factions:


### PR DESCRIPTION
## Кратное описание
<img width="498" height="166" alt="изображение" src="https://github.com/user-attachments/assets/f2574843-ff30-4448-80ec-19f51562337d" />

По хорошему лучше переработать систему телепортов призрака так, чтобы была возможность полной не отображаемости некоторых антагонистов для подавление слива информации так как ДО - скрытный антагонист. 

## По какой причине
Ранее абдукторы были в категории "Неизвесные".
https://github.com/space-sunrise/sunrise-station/issues/2418


**Changelog**

:cl: Orvex07
- fix: Диверсионный Отряд будет корректно отображатся в панели телепортов призраков



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Добавлена поддержка режима "Диверсионный отряд" с ролями командира и членов отряда.

* **Локализация**
  * Добавлены полные англоязычные локализационные строки для ролей и описания режима.
  * Добавлены русские переводы для всех текстов ролей и интерфейса.

* **Улучшения интерфейса**
  * Добавлены интерфейсные элементы для отображения информации о ролях в игровой панели.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->