### PR TITLE
Фикс помещения спрайтов ножей в контейнеры

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -39,6 +39,7 @@
         layer:
         - MachineLayer
   - type: EntityStorage
+    maxSize: 1.05 # Sunrise edit - неправильные спрайты в ящиках (#3611)
   - type: PlaceableSurface
     isPlaceable: false # defaults to closed.
   - type: Damageable


### PR DESCRIPTION
[#3611](https://github.com/space-sunrise/sunrise-station/issues/3611)

Во время проверки в SharedEntityStorageSystem, некоторые спрайты имеют неточные размеры после фикса офов (aabb.Size 1.05 вместо 1). 
Ящик вмещает предметы размерами до 1, поэтому увеличен размер вмещаемых предметов в локерах до 1.05 (не должно повлиять на функциональность), чтобы вмещались такие спрайты. 

![storage](https://github.com/user-attachments/assets/67def30b-ce52-4d5c-b8c6-9b0cc71a68f6)
