### PR TITLE
Фикс игнорирования отсутствия гравитации боргами

### DIFF
--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -27,7 +27,6 @@ public sealed class SharedMagbootsSystem : EntitySystem
         SubscribeLocalEvent<MagbootsComponent, ClothingGotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<MagbootsComponent, ClothingGotUnequippedEvent>(OnGotUnequipped);
         SubscribeLocalEvent<MagbootsComponent, IsWeightlessEvent>(OnIsWeightless);
-        SubscribeLocalEvent<BorgMagbootsComponent, IsWeightlessEvent>(OnIsWeightless);
         SubscribeLocalEvent<MagbootsComponent, InventoryRelayedEvent<IsWeightlessEvent>>(OnIsWeightless);
     }
 
@@ -62,19 +61,6 @@ public sealed class SharedMagbootsSystem : EntitySystem
     }
 
     private void OnIsWeightless(Entity<MagbootsComponent> ent, ref IsWeightlessEvent args)
-    {
-        if (args.Handled || !_toggle.IsActivated(ent.Owner))
-            return;
-
-        // do not cancel weightlessness if the person is in off-grid.
-        if (ent.Comp.RequiresGrid && !_gravity.EntityOnGravitySupportingGridOrMap(ent.Owner))
-            return;
-
-        args.IsWeightless = false;
-        args.Handled = true;
-    }
-
-    private void OnIsWeightless(Entity<BorgMagbootsComponent> ent, ref IsWeightlessEvent args)
     {
         if (args.Handled || !_toggle.IsActivated(ent.Owner))
             return;


### PR DESCRIPTION
[#3678](https://github.com/space-sunrise/sunrise-station/issues/3678)

Из-за перегрузки метода `OnIsWeightless` для компонента `BorgMagbootsComponent` в `MagbootsSystem` на боргов не влияла гравитация, даже если ботинки отключены. 

Перенесена логика бутсов для боргов в `BorgMagbootsSystem` для чистоты кода; исправлено поведение хандлера ивента потери гравы: заменен неиспользуемый флаг `_toggle.IsActivated(ent.Owner)` на `ent.Comp.On`

Удален неиспользованный импорт.

![ezgif-31603e1e80b7437f](https://github.com/user-attachments/assets/559c86b6-66d3-48ca-8e3b-d86dcce592da)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения игровой механики**
  * Оптимизирована система обработки магнитных сапог при взаимодействии с гравитацией и состояниями невесомости.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->