### PR TITLE
ПТ | заменил у Разнорабочего Гарнитуру сервиса на Гарнитуру сб

### DIFF
--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/PlanetPrison/prison_worker.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/PlanetPrison/prison_worker.yml
@@ -49,7 +49,7 @@
   equipment:
     id: PrisonWorkerPDA
     jumpsuit: UniformPrisonWorkerMetus
-    ears: ClothingHeadsetService
+    ears: ClothingHeadsetSecurity
     eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterArmorBasic
@@ -65,7 +65,7 @@
   equipment:
     jumpsuit: UniformPrisonWorkerMetus
     head: ClothingHeadCapPrisonWorkerMetus
-    ears: ClothingHeadsetService
+    ears: ClothingHeadsetSecurity
     eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterArmorBasic


### PR DESCRIPTION
## Кратное описание
Просто заменил в лодауте разнорабочего ClothingHeadsetService на ClothingHeadsetSecurity

## По какой причине
Нет канала СБ в гарнитуре 

## Медиа(Видео/Скриншоты)
ДО:
<img width="573" height="323" alt="изображение" src="https://github.com/user-attachments/assets/1ec7c13b-9634-420b-bb0b-bece49b1fe7a" />
ПОСЛЕ:
<img width="570" height="300" alt="изображение" src="https://github.com/user-attachments/assets/a6c84d16-f953-4d94-9821-824918492a20" />

**Changelog**
:cl: ПТ | KAVALDi
- fix: Заменил у роли ПТ разнорабочего Гарнитуру сервиса на Гарнитуру сб

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения оборудования**
  * Обновлена гарнитура для работников тюрьмы в стандартном наборе снаряжения и специальном костюме. Изменения повышают соответствие оборудования требованиям роли.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->