### PR TITLE
Фикс проверок коллизии шлюзов

### DIFF
--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -27,7 +27,7 @@ namespace Content.IntegrationTests.Tests.Doors
       fix1:
         shape:
           !type:PhysShapeCircle
-            bounds: ""-0.49,-0.49,0.49,0.49""
+            bounds: ""-0.46,-0.46,0.46,0.46""
         layer:
         - Impassable
 
@@ -47,10 +47,10 @@ namespace Content.IntegrationTests.Tests.Doors
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: ""-0.49,-0.49,0.49,0.49""
+            bounds: ""-0.46,-0.46,0.46,0.46""
         mask:
         - Impassable
-";
+"; // Sunrise edit - фикс двойных шлюзов (было 0.49)
         [Test]
         public async Task OpenCloseDestroyTest()
         {

--- a/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
@@ -24,10 +24,10 @@ namespace Content.IntegrationTests.Tests.Utility
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: ""-0.49,-0.49,0.49,0.49""
+            bounds: ""-0.46,-0.46,0.46,0.46""
         mask:
         - Impassable
-";
+"; // Sunrise edit - фикс двойных шлюзов (было 0.49)
 
         [Test]
         public async Task Test()

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -59,7 +59,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+          bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
         density: 100
         mask:
         - FullTileMask
@@ -224,7 +224,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+          bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
         density: 100
         mask:
         - FullTileMask

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -37,7 +37,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+          bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
         density: 100
         mask:
         - FullTileMask

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -16,7 +16,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+          bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
         density: 100
         mask:
           - FullTileMask

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -80,7 +80,7 @@
         fix1:
           shape:
             !type:PhysShapeAabb
-            bounds: "-0.49,-0.49,0.49,0.49"  # don't want this colliding with walls or they won't close
+            bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
           density: 100
           mask:
           - FullTileMask
@@ -183,7 +183,7 @@
         fix1:
           shape:
             !type:PhysShapeAabb
-            bounds: "-0.49,-0.49,0.49,0.49"  # don't want this colliding with walls or they won't close
+            bounds: "-0.46,-0.46,0.46,0.46"  # Sunrise edit - фикс двойных шлюзов
           mask:
           - Impassable
           - HighImpassable
@@ -213,7 +213,7 @@
         fix1:
           shape:
             !type:PhysShapeAabb
-            bounds: "-0.49,-0.49,0.49,-0.2" # don't want this colliding with walls or they won't close
+            bounds: "-0.46,-0.46,0.46,-0.2" # Sunrise edit - фикс двойных шлюзов
           mask:
           - Impassable
           - HighImpassable

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -24,7 +24,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49"
+          bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
         density: 100
         mask:
         - FullTileMask

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -22,7 +22,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49"
+          bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
         density: 100
         mask:
         - FullTileMask

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -27,7 +27,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+          bounds: "-0.46,-0.46,0.46,0.46" # Sunrise edit - фикс двойных шлюзов
         density: 100
         mask:
         - FullTileMask

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -22,7 +22,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,-0.36"
+          bounds: "-0.46,-0.46,0.46,-0.36" # Sunrise edit - фикс двойных шлюзов
         density: 1500
         mask:
         - TabletopMachineMask

--- a/Resources/Prototypes/_Sunrise/BloodCult/Entities/other_structures.yml
+++ b/Resources/Prototypes/_Sunrise/BloodCult/Entities/other_structures.yml
@@ -15,7 +15,7 @@
         airlockFix:
           shape:
             !type:PhysShapeAabb
-            bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+            bounds: "-0.46,-0.46,0.46,0.46" # don't want this colliding with walls or they won't close
           density: 100
           mask:
             - FullTileMask

--- a/Resources/Prototypes/_Sunrise/Entities/Structures/Doors/Airlocks/Glass/airlocks.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Structures/Doors/Airlocks/Glass/airlocks.yml
@@ -26,7 +26,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,1.49,0.49" # don't want this colliding with walls or they won't close
+          bounds: "-0.46,-0.46,1.46,0.46" # don't want this colliding with walls or they won't close
         density: 100
         mask:
         - FullTileMask
@@ -55,7 +55,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-1.49,-0.49,1.49,0.49" # don't want this colliding with walls or they won't close
+          bounds: "-1.46,-0.46,1.46,0.46" # don't want this colliding with walls or they won't close
         density: 100
         mask:
         - FullTileMask

--- a/Resources/Prototypes/_Sunrise/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -18,7 +18,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49"
+          bounds: "-0.46,-0.46,0.46,0.46"
         density: 100
         mask:
         - FullTileMask


### PR DESCRIPTION
[#3714](https://github.com/space-sunrise/sunrise-station/issues/3714)

После смены проверки на aabb, двери некорректно проверяли коллизию из-за того, что:

- aabb размер шлюза больше реального спрайта
- Необходимо использовать GetLocalPhysicsTransform вместо обычного, так как обычный PhysicsTransform неправильно считает aabb шлюзов

Изменил размеры шлюзов в прототипах, чтобы новый фикс выталкивания работал.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Улучшена механика обнаружения столкновений дверей: проверка стала локальнее и точнее, уменьшены ложные срабатывания; теперь корректно пропускается при отсутствии физической информации.
* **Изменения контента**
  * Уточнены границы коллизий для множества дверных прототипов (небольшое сужение AABB), что снижает нежелательные пересечения с окружением.
* **Тесты**
  * Обновлены интеграционные тесты, отражающие новые границы коллизий.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->