### PR TITLE
ПТ | Исправил дубликат униформы в лодауте  Заключённого ПТ на юбку

### DIFF
--- a/Resources/Prototypes/_Sunrise/Loadouts/Jobs/Security/prisoner.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/Jobs/Security/prisoner.yml
@@ -6,4 +6,4 @@
 - type: loadout
   id: PrisonerJumpskirt
   equipment:
-    jumpsuit: ClothingUniformJumpsuitPrisonerGrey
+    jumpsuit: ClothingUniformJumpskirtPrisonerGrey


### PR DESCRIPTION
## Кратное описание
Изменение в одно слово: заменил айдишник второго слота в лодауте, с униформы на юбку - всё.

## По какой причине
Было дублирование униформы в лодауте Заключённого ПТ.
(теперь вторым слотом там юбка)

## Медиа(Видео/Скриншоты)
<details>
  <summary>баг</summary>
<img width="725" height="257" alt="{BB1110A4-8729-40DD-AA56-0818B3E04A89}" src="https://github.com/user-attachments/assets/9e80aa41-533a-4795-83fb-6cb4231f3295" />
</details>

<details>
  <summary>баг сврегнут</summary>
<img width="724" height="255" alt="{CFB22448-9419-4243-9B41-6FC0F28BB3F8}" src="https://github.com/user-attachments/assets/9c9409fe-08f6-43c2-ad6f-40f26b5fc637" />
</details>

**Changelog**
:cl: ПТ | KAVALDi
- fix: Исправлено дублирование униформы в лодауте Заключённого ПТ (теперь второй слот одежды - юбка)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Chores**
  * Обновлена форма одежды для тюремного персонала.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->