### PR TITLE
Фикс анимаций прыжка при низкой стамине

### DIFF
--- a/Content.Client/_Sunrise/Animations/EmoteAnimationSystem.cs
+++ b/Content.Client/_Sunrise/Animations/EmoteAnimationSystem.cs
@@ -15,6 +15,7 @@ public sealed class EmoteAnimationSystem : EntitySystem
 
     public const string AnimationKey = "emoteAnimationKeyId";
     private const string AnimationKeyTurn = "emoteAnimationKeyId_rotate";
+    private const string StaminaAnimationKey = "stamina";
 
     public override void Initialize()
     {
@@ -55,10 +56,13 @@ public sealed class EmoteAnimationSystem : EntitySystem
             _animationSystem.Play(uid, animation, AnimationKey);
         });
 
+        // Анимация прыжка использует слот FatigueAnimation (StaminaAnimationKey),
+        // перехватывая его у периодической анимации из StunSystem, которая тоже имеет offset
+        // Это решает конфликт KeyFrame при одновременном наложении двух анимаций
         _emoteList.Add("Jump", uid =>
         {
-            if (_animationSystem.HasRunningAnimation(uid, AnimationKey))
-                return;
+            if (_animationSystem.HasRunningAnimation(uid, StaminaAnimationKey))
+                _animationSystem.Stop(uid, StaminaAnimationKey);
 
             var animation = new Animation
             {
@@ -82,7 +86,7 @@ public sealed class EmoteAnimationSystem : EntitySystem
                 }
             };
 
-            _animationSystem.Play(uid, animation, AnimationKey);
+            _animationSystem.Play(uid, animation, StaminaAnimationKey);
         });
 
         _emoteList.Add("Dance", uid =>


### PR DESCRIPTION
[#3739](https://github.com/space-sunrise/sunrise-station/issues/3739)

При низкой стамине модельке включается анимация тряски из StunSystem, которая применяется периодически и не дает проигрывать другие анимации. 

Заменен ID прыжка на ID тряски с оверрайдом текущей активной `FatigueAnimation`, чтобы вставить кастомную анимацию посреди тиков FatigueAnimation.  

![jump](https://github.com/user-attachments/assets/ada436f5-d8ec-428c-be8c-16c7a7f095a2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Анимация прыжка теперь использует слот усталости/выносливости и больше не конфликтует с периодическими анимациями этого слота; при совпадении ранее запущенные анимации на этом слоте автоматически останавливаются, что обеспечивает более плавное и предсказуемое воспроизведение прыжков персонажа.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->