### PR TITLE
Убрал длинное тире (—) и числа с точкой (7.62) из авто очистки

### DIFF
--- a/Content.Server/_Sunrise/Chat/Sanitization/ChatSanitizationSystem.cs
+++ b/Content.Server/_Sunrise/Chat/Sanitization/ChatSanitizationSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class ChatSanitizationSystem : EntitySystem
     /// Расширенный паттерн для обнаружения ссылок.
     /// </summary>
     private static readonly Regex UrlRegex =
-        new(@"(?<!\d)\b[-a-zA-Z0-9@:%._+~#=]{1,256}.[a-zA-Z]{2,6}\b(?!\d)", RegexOptions.Compiled);
+        new(@"(?<!\d)\b[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z]{2,6}\b(?!\d)", RegexOptions.Compiled);
 
     /// <summary>
     /// ASCII-art фильтр: отбрасывает нестандартные символы, но сохраняет все локали и управляемые символы.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Убрал длинное тире (—) и числа с точкой (7.62) из авто очистки

## По какой причине
Меня попросили, я подумал а че бы нет

## Медиа(Видео/Скриншоты)
<img width="549" height="145" alt="Снимок экрана (4835)" src="https://github.com/user-attachments/assets/d19b2067-57b9-40ab-8d5d-232ea0317bc4" />
<img width="566" height="283" alt="Снимок экрана (4838)" src="https://github.com/user-attachments/assets/2aaf2bf6-1d20-495a-9422-34e653656b6f" />
<img width="539" height="389" alt="Снимок экрана (4837)" src="https://github.com/user-attachments/assets/b9cf9086-bbac-44c7-9896-111c0785b5e9" />


**Changelog**

:cl: Kinar_7
- tweak: Убрал длинное тире (—) и числа с точкой (7.62) из авто очистки чата



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Улучшена система фильтрации сообщений чата: более точное обнаружение и блокировка ссылок в тексте.
  * Расширена защита от нежелательных символов — добавлен дополнительный символ в чёрный список фильтрации.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->