### PR TITLE
Фикс присоединения и ампутаций предметов

### DIFF
--- a/Content.Client/_Starlight/Medical/Surgery/CustomLimbVisualizerSystem.cs
+++ b/Content.Client/_Starlight/Medical/Surgery/CustomLimbVisualizerSystem.cs
@@ -121,6 +121,7 @@ public sealed class CustomLimbVisualizerSystem : EntitySystem
             {
                 var index = sprite.LayerMapReserveBlank($"custom-{layer}");
                 sprite.LayerSetVisible(layer, false);
+                sprite.LayerSetVisible($"custom-{layer}", false);
             }
     }
 }

--- a/Content.Server/_Starlight/Medical/Limbs/LimbSystem.Visual.cs
+++ b/Content.Server/_Starlight/Medical/Limbs/LimbSystem.Visual.cs
@@ -4,10 +4,10 @@ using Content.Shared._Sunrise;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Humanoid;
-using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Starlight;
 
 namespace Content.Server._Starlight.Medical.Limbs;
+
 public sealed partial class LimbSystem : SharedLimbSystem
 {
     public void AddLimbVisual(Entity<HumanoidAppearanceComponent> body, Entity<BodyPartComponent> limb)

--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -7,10 +7,8 @@ using Content.Shared.Body.Components;
 using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
-using Content.Shared.Damage;
 using Content.Shared.Humanoid;
 using Content.Shared.Traits.Assorted;
-using Microsoft.CodeAnalysis;
 using Content.Server._Starlight.Medical.Limbs;
 using Content.Server.Administration.Systems;
 using Content.Shared.Bed.Sleep;
@@ -170,8 +168,8 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     private void OnStepAmputationComplete(Entity<SurgeryStepAmputationEffectComponent> ent, ref SurgeryStepEvent args)
     {
         if (_entity.TryEntity<TransformComponent, HumanoidAppearanceComponent, BodyComponent>(args.Body, out var body)
-            && _entity.TryEntity<TransformComponent, MetaDataComponent, BodyPartComponent>(args.Part, out var limb))
-            _limbSystem.Amputatate(body, limb);
+            && _entity.TryEntity<TransformComponent, MetaDataComponent>(args.Part, out var limb))
+            _limbSystem.Amputate(body, limb);
     }
 
     private void CustomLimbRemoved(Entity<CustomLimbMarkerComponent> ent, ref ComponentRemove args)

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -21,7 +21,6 @@
     tags:
       - Trash
   # Sunrise-start
-  - type: SurgeryTarget
   - type: UserInterface
     interfaces:
       enum.SurgeryUIKey.Key:

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -48,6 +48,7 @@
     voice: Portal2FactCore # Sunrise-TTS
   - type: StaticPrice
     price: 0 # Sunrise-TTS
+  - type: SurgeryTarget # Sunrise added
 
 - type: entity
   name: "storage item"


### PR DESCRIPTION
[#3749](https://github.com/space-sunrise/sunrise-station/issues/3749)

Добавил `SurgeryTargetComponent` для `BaseItem` вместо `BasePart`, чтобы предметы были корректной целью шагов операции;
Исправлен баг с недоудалением спрайтов при ампутации, из-за чего предметы вместо конечностей визуально оставались на том же месте при ампутации;
Немного подправил типы, название функции и убрал лишние импорты.


https://github.com/user-attachments/assets/ef0b7ed4-2422-4dae-8c9c-daf81e594b55



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Исправлена очистка пользовательских слоёв при деактивации слоёв медицинских конечностей.

* **Рефакторинг**
  * Оптимизирована система ампутации с улучшенной обработкой компонентов конечностей.

* **Изменения конфигурации**
  * Перемещён компонент системы между прототипами для улучшенной организации элементов.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->