### PR TITLE
Фальшфаеры в Техфаб СБ

### DIFF
--- a/Resources/Prototypes/_Sunrise/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Lathes/ammo.yml
@@ -1220,4 +1220,3 @@
     Steel: 500
     Plastic: 150
     Gold: 50
-


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Фальфаеры теперь будут в техфабе Сб

## По какой причине
Фальшаеры это ультимативный способ осветить темное помещение, без фонариков и без подвержение себя опасности


**Changelog**

:cl: Kinar_7
- add: Фальшфаеры теперь можно создать в техфабе СБ в начале раунда


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен новый огневой предмет "Box Shotgun Flare", доступный для создания в категории безопасности.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->