### PR TITLE
ПТ | фикс наигранного времени на Заключённом ПТ

### DIFF
--- a/Resources/Prototypes/_Sunrise/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/play_time_trackers.yml
@@ -59,6 +59,9 @@
   id: JobPlanetPrisoner
 
 - type: playTimeTracker
+  id: AntagPlanetPrisoner
+
+- type: playTimeTracker
   id: JobHeadOfPrison
 
 - type: playTimeTracker


### PR DESCRIPTION
## Кратное описание
Добавил айдишник антаг роли Зека в тайм трекер:

## По какой причине
Суть в том, что обычный (джобный) айдишник зека есть в тайм трекере, а вот его айдишник антага нет, потому и слетело наигранное время на нём.

**Changelog**
:cl: ПТ | KAVALDi
- fix: Исправлена пропажа наигранных часов за роль Заключённого ПТ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к релизу

* **Новые возможности**
  * Добавлен новый вариант роли, доступный для игровой механики отслеживания времени игры.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->