### PR TITLE
ПТ | Добавлен StationNewsComponent для NanotrasenPrison

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Stations/nanotrasen.yml
@@ -2,6 +2,7 @@
   id: NanotrasenPrison
   parent:
   - BaseStation
+  - BaseStationNews
   - BaseStationJobsSpawning
   - BaseStationRecords
   - BaseStationNanotrasen


### PR DESCRIPTION
## Кратное описание
Добавил в базовую станцию NanotrasenPrison, от которой наследуются карты ПТ, компонент для поддержка системы новостей на них.

## По какой причине
На картах ПТ нет StationNewsComponent, из-за чего не работала **консоль управления новостями** (ComputerMassMedia). 
Компонент нужен, ибо на картах Nox и Metus есть эта консоль.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления версии

* **Новые возможности**
  * Тюремная станция Нанотрейсена теперь располагает функциональностью новостей. Члены экипажа смогут получать и просматривать актуальную информацию о событиях, обновлениях и уведомлениях, что позволит им быть в курсе последних происходящих событий.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->