### PR TITLE
нерф Хиллума

### DIFF
--- a/Content.Server/Atmos/Reactions/HealiumProductionReaction.cs
+++ b/Content.Server/Atmos/Reactions/HealiumProductionReaction.cs
@@ -21,7 +21,7 @@ public sealed partial class HealiumProductionReaction : IGasReactionEffect
 
         var bZRemoved = 3f * rate;
         var frezonRemoved = 30f * rate;
-        var healiumProduced = 45f * rate * efficiency;
+        var healiumProduced = 4.5f * rate * efficiency;
 
         if (bZRemoved > initBZ || frezonRemoved > initFrezon || mixture.Temperature > Atmospherics.T20C)
             return ReactionResult.NoReaction;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Теперь вырабатывается в 10 раз меньше газа

## По какой причине
Джунтер сказал что нужно нерфнуть хиллиум, что бы люди не создавали за 1 час газа на миллион.

**Changelog**
:cl: Kinar_7 
- tweak: Вы чувствуете, что правила мироздания изменились. Вы слышите, как слово "ХИЛЛИУМ" отдается эхом и меняется в красках



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Балансировка**
  * Скорость производства Healium снижена в десять раз. Это изменение влияет на накопление ресурса во время игровой сессии.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->