### PR TITLE
Возможный фикс утечки памяти в меню аплинка с музыкой

### DIFF
--- a/Content.Client/_Sunrise/TapePlayer/TapePlayerBoundUserInterface.cs
+++ b/Content.Client/_Sunrise/TapePlayer/TapePlayerBoundUserInterface.cs
@@ -61,7 +61,7 @@ public sealed class TapePlayerBoundUserInterface : BoundUserInterface
         if (_entityManager.TryGetComponent<MusicTapeComponent>(tapePlayer.InsertedTape, out var musicTapeComponent))
         {
             var audio = EntMan.System<AudioSystem>();
-            var length = audio.GetAudioLength(audio.GetSound(musicTapeComponent.Sound));
+            var length = audio.GetAudioLength(audio.ResolveSound(musicTapeComponent.Sound));
             _menu.SetSelectedSong(musicTapeComponent.SongName, (float) length.TotalSeconds);
         }
         else
@@ -104,7 +104,7 @@ public sealed class TapePlayerBoundUserInterface : BoundUserInterface
             return;
 
         _menu.OnClose -= Close;
-        _menu.Dispose();
+        _menu.Orphan();
         _menu = null;
     }
 }

--- a/Content.Client/_Sunrise/TapePlayer/TapePlayerSystem.cs
+++ b/Content.Client/_Sunrise/TapePlayer/TapePlayerSystem.cs
@@ -46,6 +46,9 @@ namespace Content.Client._Sunrise.TapePlayer
 
         private void OnTapePlayerAfterState(Entity<TapePlayerComponent> ent, ref AfterAutoHandleStateEvent args)
         {
+            if (IsClientSide(ent))
+                return;
+
             if (!_uiSystem.TryGetOpenUi<TapePlayerBoundUserInterface>(ent.Owner, TapePlayerUiKey.Key, out var bui))
                 return;
 

--- a/Content.Shared/_Sunrise/TapePlayer/MusicTapeComponent.cs
+++ b/Content.Shared/_Sunrise/TapePlayer/MusicTapeComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._Sunrise.TapePlayer
     [RegisterComponent, NetworkedComponent]
     public sealed partial class MusicTapeComponent : Component
     {
-        [DataField(customTypeSerializer: typeof(SoundSpecifierTypeSerializer), required: true)]
+        [DataField(required: true)]
         public SoundSpecifier Sound;
 
         [DataField]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

(для будущих поколений) Проблема где-то здесь

```csharp
public void Reload()
{
    if (_menu == null || !EntMan.TryGetComponent(Owner, out TapePlayerComponent? tapePlayer))
        return;

    _menu.SetAudioStream(tapePlayer.AudioStream);
    _menu.SetVolumeSlider(tapePlayer.Volume * 100f);

    if (_entityManager.TryGetComponent<MusicTapeComponent>(tapePlayer.InsertedTape, out var musicTapeComponent))
    {
        var audio = EntMan.System<AudioSystem>();
        var length = audio.GetAudioLength(audio.GetSound(musicTapeComponent.Sound));
        _menu.SetSelectedSong(musicTapeComponent.SongName, (float) length.TotalSeconds);
    }
    else
    {
        _menu.SetSelectedSong(string.Empty, 0f);
    }
}
```

```csharp
private void OnTapePlayerAfterState(Entity<TapePlayerComponent> ent, ref AfterAutoHandleStateEvent args)
{
    if (!_uiSystem.TryGetOpenUi<TapePlayerBoundUserInterface>(ent.Owner, TapePlayerUiKey.Key, out var bui))
        return;

    bui.Reload();
}
```

Этот код вызывает данный клиентский метод движка

```csharp
protected override TimeSpan GetAudioLengthImpl(string filename)
{
    return _resourceCache.GetResource<AudioResource>(filename).AudioStream.Length;
}
```

_resourceCache.GetResource создает Disposable объект, который нужно диспозить вручную. Но это сделать невозможно из нашего метода

1) Ресурс после выхода из GetResource превращается в тыкву, которая не имеет свойства Disposable, но оригинальный объект до конверсии его имел и должен был вручную диспозиться. Оперативка забилась, но инструмент очистки отобрали
2) GetAudioLengthImpl() отдает TimeSpan и никак не позволяет взаимодействовать с объектом.


Закрыл проблему через IsClientSide(), что по факту чинит проблему лишь в меню аплика(пока ентити не создан). Но когда он будет создан - утечка никуда не денется. Еще возможно PVS будет усилить проблему постоянно пересоздавая ентити

```csharp
        private void OnTapePlayerAfterState(Entity<TapePlayerComponent> ent, ref AfterAutoHandleStateEvent args)
        {
            if (IsClientSide(ent))
                return;

            if (!_uiSystem.TryGetOpenUi<TapePlayerBoundUserInterface>(ent.Owner, TapePlayerUiKey.Key, out var bui))
                return;

            bui.Reload();
        }
```

**Changelog**

:cl: ThereDrD
- fix: Возможно исправлена огромная утечка памяти в меню музыки донат аплинка


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **Исправления ошибок**
  * Улучшена обработка аудиоданных для плеера музыкальных кассет
  * Оптимизирована логика обновления интерфейса для предотвращения ненужных перезагрузок

* **Рефакторинг**
  * Упрощены механизмы сериализации компонентов плеера
  * Улучшена очистка ресурсов меню

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->