### PR TITLE
Конфигурируемые цены газов в CVars

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -25,7 +25,12 @@ public partial class AtmosphereSystem
         float maxComponent = 0; // moles of the dominant gas
         for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
         {
-            basePrice += mixture.Moles[i] * GetGas(i).PricePerMole;
+            // Sunrise edit start - gas price CVar modifiers
+            var gas = GetGas(i);
+            var modifier = GetModifier(gas.ID);
+            basePrice += mixture.Moles[i] * gas.PricePerMole * modifier;
+            // Sunrise edit end
+
             totalMoles += mixture.Moles[i];
             maxComponent = Math.Max(maxComponent, mixture.Moles[i]);
         }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -79,6 +79,8 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
 
         CacheDecals();
+
+        InitSunriseAtmosCVars(); // Sunrise edit - Atmos CVars
     }
 
     public override void Shutdown()
@@ -86,6 +88,8 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
         base.Shutdown();
 
         ShutdownCommands();
+
+        ShutdownSunriseAtmosCVars(); // Sunrise edit - Atmos CVars
     }
 
     private void OnTileChanged(ref TileChangedEvent ev)

--- a/Content.Server/_Sunrise/Atmos/EntitySystems/AtmosphereSystem.CCVars.cs
+++ b/Content.Server/_Sunrise/Atmos/EntitySystems/AtmosphereSystem.CCVars.cs
@@ -1,0 +1,66 @@
+using Content.Shared._Sunrise.SunriseCCVars;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+public enum GasIds
+{
+    Tritium,
+    NitrousOxide,
+    Frezon,
+    BZ,
+    Healium,
+    Nitrium
+}
+
+public partial class AtmosphereSystem
+{
+    private float _defaultGasPriceModifier;
+    private float _gasPriceModifierTritium;
+    private float _gasPriceModifierNitrousOxide;
+    private float _gasPriceModifierFrezon;
+    private float _gasPriceModifierBZ;
+    private float _gasPriceModifierHealium;
+    private float _gasPriceModifierNitrium;
+
+    private IDisposable? _configSub;
+
+    public void InitSunriseAtmosCVars()
+    {
+        if (_configSub is not null)
+        {
+            return;
+        }
+
+        _configSub = _cfg.SubscribeMultiple()
+            .OnValueChanged(SunriseCCVars.DefaultGasPriceModifier, (value) => _defaultGasPriceModifier = value, true)
+            .OnValueChanged(SunriseCCVars.GasPriceModifierTritium, (value) => _gasPriceModifierTritium = value, true)
+            .OnValueChanged(SunriseCCVars.GasPriceModifierNitrousOxide, (value) => _gasPriceModifierNitrousOxide = value, true)
+            .OnValueChanged(SunriseCCVars.GasPriceModifierFrezon, (value) => _gasPriceModifierFrezon = value, true)
+            .OnValueChanged(SunriseCCVars.GasPriceModifierBZ, (value) => _gasPriceModifierBZ = value, true)
+            .OnValueChanged(SunriseCCVars.GasPriceModifierHealium, (value) => _gasPriceModifierHealium = value, true)
+            .OnValueChanged(SunriseCCVars.GasPriceModifierNitrium, (value) => _gasPriceModifierNitrium = value, true);
+    }
+
+    public float GetModifier(string id)
+    {
+        if (!Enum.TryParse<GasIds>(id, out var gasId))
+            return _defaultGasPriceModifier;
+
+        return gasId switch
+        {
+            GasIds.Tritium => _gasPriceModifierTritium,
+            GasIds.NitrousOxide => _gasPriceModifierNitrousOxide,
+            GasIds.Frezon => _gasPriceModifierFrezon,
+            GasIds.BZ => _gasPriceModifierBZ,
+            GasIds.Healium => _gasPriceModifierHealium,
+            GasIds.Nitrium => _gasPriceModifierNitrium,
+            _ => _defaultGasPriceModifier,
+        };
+    }
+
+    private void ShutdownSunriseAtmosCVars()
+    {
+        _configSub?.Dispose();
+    }
+}

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Atmos.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Atmos.cs
@@ -1,0 +1,32 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Sunrise.SunriseCCVars;
+
+public sealed partial class SunriseCCVars
+{
+    /// <summary>
+    /// These variables control modifications of various gas prices. If gas has no specified
+    /// modifier here, it will use default price from prototype
+    /// </summary>
+
+    public static readonly CVarDef<float> DefaultGasPriceModifier =
+        CVarDef.Create("atmos.gas_price_modifier_default", 1f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierTritium =
+        CVarDef.Create("atmos.gas_price_modifier_tritium", 0.016f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierNitrousOxide =
+        CVarDef.Create("atmos.gas_price_modifier_nitrous_oxide", 2f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierFrezon =
+        CVarDef.Create("atmos.gas_price_modifier_frezon", 0.25f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierBZ =
+        CVarDef.Create("atmos.gas_price_modifier_bz", 1f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierHealium =
+        CVarDef.Create("atmos.gas_price_modifier_healium", 1f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierNitrium =
+        CVarDef.Create("atmos.gas_price_modifier_nitrium", 1f, CVar.SERVER);
+}

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 0.04 #Sunrise-edit
+  pricePerMole: 2.5
 
 - type: gas
   id: WaterVapor
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 0.5 # Sunrise-Edit
+  pricePerMole: 0.1
 
 - type: gas
   id: Frezon
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 0.25 # Sunrise-Edit
+  pricePerMole: 1

--- a/Resources/Prototypes/_Sunrise/Atmospherics/gases.yml
+++ b/Resources/Prototypes/_Sunrise/Atmospherics/gases.yml
@@ -1,3 +1,6 @@
+# If you will add more custom gases here, consider adding CVars for
+# making it's price configurable -> _Sunrise\Atmos\EntitySystems\AtmosphereSystem.CCVars.cs
+
 - type: gas
   id: BZ
   name: gases-bz


### PR DESCRIPTION
Вынесены цены газов в CVars для учета динамики различных сборок

Изменения из прототипов перенесены в CVar'ы `GasPriceModifier${ID}` с дефолтным значением множителя 1, если CVar не указан или не существует (цена из прототипа).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Добавлена настраиваемая система модификаторов цен для отдельных газов через конфигурационные переменные (позволяет регулировать цены в реальном времени).

* **Баланс**
  * Обновлены цены на газы: Тритий 0.04 → 2.5, Закись азота 0.5 → 0.1, Фрезон 0.25 → 1.

* **Прочее**
  * Небольшие правки в прототипах газов и комментариях конфигурации.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->