### PR TITLE
ПТ | Добавил консоль ID карт тюрьмы

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
+++ b/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
@@ -35,10 +35,12 @@ namespace Content.Client.Access.UI
         {
             base.Open();
             List<ProtoId<AccessLevelPrototype>> accessLevels;
+            List<ProtoId<JobPrototype>> allowedJobs = new(); // Sunrise-Edit
 
             if (EntMan.TryGetComponent<IdCardConsoleComponent>(Owner, out var idCard))
             {
                 accessLevels = idCard.AccessLevels;
+                allowedJobs = idCard.AllowedJobs; // Sunrise-Edit
             }
             else
             {
@@ -46,7 +48,7 @@ namespace Content.Client.Access.UI
                 _idCardConsoleSystem.Log.Error($"No IdCardConsole component found for {EntMan.ToPrettyString(Owner)}!");
             }
 
-            _window = new IdCardConsoleWindow(this, _prototypeManager, accessLevels)
+            _window = new IdCardConsoleWindow(this, _prototypeManager, accessLevels, allowedJobs) // Sunrise added edit
             {
                 Title = EntMan.GetComponent<MetaDataComponent>(Owner).EntityName
             };

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -68,7 +68,19 @@ namespace Content.Client.Access.UI
             JobTitleSaveButton.OnPressed += _ => SubmitData();
 
             var jobs = _prototypeManager.EnumeratePrototypes<JobPrototype>().ToList();
-            jobs.Sort((x, y) => string.Compare(x.LocalizedName, y.LocalizedName, StringComparison.CurrentCulture));
+
+            // Sunrise-Start
+            // If allowed jobs list is specified, sort jobs according to the allowedJobs order
+            if (_allowedJobs.Count > 0)
+            {
+                jobs = jobs.Where(job => _allowedJobs.Contains(job.ID))
+                          .OrderBy(job => _allowedJobs.IndexOf(job.ID))
+                          .ToList();
+            }
+            else
+            {  // Sunrise-End
+                jobs.Sort((x, y) => string.Compare(x.LocalizedName, y.LocalizedName, StringComparison.CurrentCulture));
+            }  // Sunrise-Edit
 
             foreach (var job in jobs)
             {

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace Content.Client.Access.UI
 
         private AccessLevelControl _accessButtons = new();
         private readonly List<string> _jobPrototypeIds = new();
+        private readonly List<ProtoId<JobPrototype>> _allowedJobs; // Sunrise-Edit
 
         private string? _lastFullName;
         private string? _lastJobTitle;
@@ -38,13 +39,14 @@ namespace Content.Client.Access.UI
         private static ProtoId<JobPrototype> _defaultJob = "Passenger";
 
         public IdCardConsoleWindow(IdCardConsoleBoundUserInterface owner, IPrototypeManager prototypeManager,
-            List<ProtoId<AccessLevelPrototype>> accessLevels)
+            List<ProtoId<AccessLevelPrototype>> accessLevels, List<ProtoId<JobPrototype>> allowedJobs) // Sunrise added edit
         {
             RobustXamlLoader.Load(this);
             IoCManager.InjectDependencies(this);
             _logMill = _logManager.GetSawmill(SharedIdCardConsoleSystem.Sawmill);
 
             _owner = owner;
+            _allowedJobs = allowedJobs; // Sunrise-Edit
 
             _maxNameLength = _cfgManager.GetCVar(CCVars.MaxNameLength);
             _maxIdJobLength = _cfgManager.GetCVar(CCVars.MaxIdJobLength);
@@ -70,7 +72,18 @@ namespace Content.Client.Access.UI
 
             foreach (var job in jobs)
             {
-                if (!job.OverrideConsoleVisibility.GetValueOrDefault(job.SetPreference))
+                // Sunrise-Start
+                // If allowed jobs list is specified, only show jobs in that list
+                if (_allowedJobs.Count > 0)
+                {
+                    if (!_allowedJobs.Contains(job.ID))
+                    {
+                        continue;
+                    }
+                }
+                // Otherwise, use the default visibility logic
+                // Sunrise-End
+                else if (!job.OverrideConsoleVisibility.GetValueOrDefault(job.SetPreference)) // Sunrise added edit
                 {
                     continue;
                 }
@@ -198,14 +211,27 @@ namespace Content.Client.Access.UI
 
             var jobIndex = _jobPrototypeIds.IndexOf(state.TargetIdJobPrototype);
             // If the job index is < 0 that means they don't have a job registered in the station records
-            // or the IdCardComponent's JobPrototype field.
+            // or the IdCardComponent's JobPrototype field, or the job is not in the allowed jobs list. // Sunrise added edit
             // For example, a new ID from a box would have no job index.
             if (jobIndex < 0)
             {
                 jobIndex = _jobPrototypeIds.IndexOf(_defaultJob);
+                // Sunrise-Start
+                // If default job is also not allowed, select the first available job
+                if (jobIndex < 0 && _jobPrototypeIds.Count > 0)
+                {
+                    jobIndex = 0;
+                }
+                // Sunrise-End
             }
 
-            JobPresetOptionButton.SelectId(jobIndex);
+            // Sunrise added edit
+            // Only try to select if we have a valid index
+            if (jobIndex >= 0 && jobIndex < _jobPrototypeIds.Count)
+            {
+                JobPresetOptionButton.SelectId(jobIndex);
+            }
+            // Sunrise added edit
 
             _lastFullName = state.TargetIdFullName;
             _lastJobTitle = state.TargetIdJobTitle;

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -85,6 +85,15 @@ public sealed partial class IdCardConsoleComponent : Component
         "ResearchConsoleAccess", // Sunrise-Edit
     };
 
+    // Sunrise-Start
+    /// <summary>
+    /// If empty, all jobs with OverrideConsoleVisibility will be shown.
+    /// If populated, only jobs in this list will be shown (regardless of OverrideConsoleVisibility).
+    /// </summary>
+    [DataField]
+    public List<ProtoId<JobPrototype>> AllowedJobs = new();
+    // Sunrise-End
+
     [Serializable, NetSerializable]
     public sealed class IdCardConsoleBoundUserInterfaceState : BoundUserInterfaceState
     {

--- a/Resources/Locale/en-US/_prototypes/_sunrise/entities/structures/machines/computers/computers.ftl
+++ b/Resources/Locale/en-US/_prototypes/_sunrise/entities/structures/machines/computers/computers.ftl
@@ -5,3 +5,5 @@ ent-AbductorHumanObservationConsole = human observation console
 ent-AbductorHumanObservationConsoleEye = abductor eye
     .desc = The abductor's viewer.
     .suffix = DO NOT MAP
+ent-ComputerIdPrison = prison ID card computer
+    .desc = Terminal for programming prison employee ID cards to access parts of the prison.

--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/structures/machines/computers/computers.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/structures/machines/computers/computers.ftl
@@ -5,3 +5,5 @@ ent-AbductorHumanObservationConsole = консоль наблюдения за �
 ent-AbductorHumanObservationConsoleEye = глаз абдукторов
     .desc = Устройство наблюдения абдукторов.
     .suffix = НЕ РАЗМЕЩАТЬ НА КАРТЕ
+ent-ComputerIdPrison = консоль ID карт тюрьмы
+    .desc = Компьютер для программирования ID карт сотрудников тюрьмы, для доступа к разным частям тюрьмы.

--- a/Resources/Prototypes/_Sunrise/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Structures/Machines/Computers/computers.yml
@@ -166,11 +166,11 @@
       - Cargo
       - CargoPurchaseAccess
     allowedJobs:
-      - PrisonTrainee
-      - PrisonChef
-      - PrisonDoctor
-      - PrisonScientist
-      - PrisonEngineer
-      - PrisonWorker
-      - PrisonInspector
       - HeadOfPrison
+      - PrisonInspector
+      - PrisonWorker
+      - PrisonEngineer
+      - PrisonScientist
+      - PrisonDoctor
+      - PrisonChef
+      - PrisonTrainee

--- a/Resources/Prototypes/_Sunrise/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Structures/Machines/Computers/computers.yml
@@ -115,3 +115,62 @@
     interfaces:
      enum.CodeConsoleUiKey.Key:
         type: CodeConsoleBoundUserInterface
+
+- type: entity
+  parent: ComputerId
+  id: ComputerIdPrison
+  name: prison ID card computer
+  description: Terminal for programming prison employee ID cards to access parts of the prison.
+  components:
+  - type: Sprite
+    layers:
+    - map: ["computerLayerBody"]
+      state: computer
+    - map: ["computerLayerKeyboard"]
+      state: generic_keyboard
+    - map: ["computerLayerScreen"]
+      state: id
+      color: "#ff6600"
+    - map: ["computerLayerKeys"]
+      state: id_key
+    - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
+      state: generic_panel_open
+  - type: IdCardConsole
+    accessLevels:
+      - Command
+      - Armory
+      - Magistrat
+      - HeadOfSecurity
+      - Brig
+      - GenpopEnter
+      - GenpopLeave
+      - Security
+      - Engineering
+      - Mining
+      - Hydroponics
+      - Medical
+      - Maintenance
+      - Janitor
+      - Kitchen
+      - Mail
+      - Service
+      - Bar
+      - Theatre
+      - Chapel
+      - Atmospherics
+      - Cryogenics
+      - Chemistry
+      - External
+      - Research
+      - ResearchConsoleAccess
+      - Cargo
+      - CargoPurchaseAccess
+    allowedJobs:
+      - PrisonTrainee
+      - PrisonChef
+      - PrisonDoctor
+      - PrisonScientist
+      - PrisonEngineer
+      - PrisonWorker
+      - PrisonInspector
+      - HeadOfPrison


### PR DESCRIPTION
## Кратное описание
- Добавлена новая консоль ID карт ComputerIdPrison, предназначенная для тюремных ролей охраны.
- Добавил фильтр ролей, которые отображаются в предустанках ролей, через поле allowedJobs в компоненте IdCardConsole
  - обычная консоль ID карт теперь не показывает тюремные роли
  - тюремная консоль показывает только тюремные роли
- Добавлено в консоль ID карт тюрьмы отображение предустановок ролей не по буквенной фильтрации, а по порядку из allowedJobs:

## По какой причине
На ПТ всё это время использовалась обычная консоль ID карт, на которой помимо лишних доступов, которые на ПТ не используются, ещё и пресеты ролей со станции.

## Медиа(Скриншоты)
<img width="295" height="291" alt="{14246B46-6BCA-4BA7-BF5E-749A5545162A}" src="https://github.com/user-attachments/assets/9f6922a8-dca7-406f-945f-a2f2216d3164" />
<img width="934" height="460" alt="{D99DD25E-99D7-4F80-9689-01B85F5F0B26}" src="https://github.com/user-attachments/assets/f0b8da0d-073b-4f0a-a2de-73b78ef17987" />
<img width="925" height="457" alt="{E1D0A841-5FC1-43D8-B78F-7C3FC13BDBEB}" src="https://github.com/user-attachments/assets/859fa998-1355-42eb-b7fe-47ac58968157" />

**Changelog**
:cl: ПТ | KAVALDi
- add: Добавлена консоль ID карт тюрьмы.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **Новые возможности**
  * Добавлена фильтрация должностей для консолей программирования ID карт, позволяющая ограничивать список доступных должностей.
  * Добавлена новая консоль программирования ID карт для тюремного персонала с поддержкой настройки доступных должностей и уровней доступа.

* **Локализация**
  * Добавлена русская локализация для новой консоли программирования ID карт.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->