### PR TITLE
ПТ | Nox | Изменил количество слотов ролей | инженер[2->4], учёный[2->3], доктор[1->2] стажёр[3->5], зек [3->10]

### DIFF
--- a/Resources/Prototypes/_Sunrise/Maps/planet_prison_old.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/planet_prison_old.yml
@@ -19,24 +19,24 @@
           HeadOfPrison: [ 1, 1 ]
           PrisonInspector: [ 1, 1 ]
           PrisonWorker: [ 3, 3 ]
-          PrisonEngineer: [ 2, 2 ]
-          PrisonScientist: [ 2, 2 ]
-          PrisonDoctor: [ 1, 1 ]
+          PrisonEngineer: [ 4, 4 ]
+          PrisonScientist: [ 3, 3 ]
+          PrisonDoctor: [ 2, 2 ]
           PrisonChef: [ 1, 1 ]
-          PrisonTrainee: [ 3, 3 ]
-          PlanetPrisoner: [ 3, 3 ]
+          PrisonTrainee: [ 5, 5 ]
+          PlanetPrisoner: [ 10, 10 ]
       - type: RelativeJobsCount
         jobs:
         - targetJob: PlanetPrisoner
           dependency:
-            HeadOfPrison: 2
-            PrisonInspector: 2
-            PrisonDoctor: 2
-            PrisonChef: 2
-            PrisonEngineer: 2
-            PrisonScientist: 2
-            PrisonWorker: 2
-            PrisonTrainee: 2
+            HeadOfPrison: 1
+            PrisonInspector: 1
+            PrisonDoctor: 1
+            PrisonChef: 1
+            PrisonEngineer: 1
+            PrisonScientist: 1
+            PrisonWorker: 1
+            PrisonTrainee: 1
           maxSlots: -1
         - targetJob: PrisonTrainee
           dependency:


### PR DESCRIPTION
## Кратное описание
- В прототипе карты Nox изменил количество слотов ролей:
  - тюремный инженер - было 2 - стало 4
  - тюремный учёный - было 2 - стало 3
  - тюремный доктор - было 1 - стало 2
  - тюремный стажёр - было 3 - стало 5
  - заключённый ПТ - было 3 - стало 10

## По какой причине
Была их нехватка.
С зеками всё проще: много кто раундстартом заходит на него, поэтому слоты увеличил.

**Changelog**
:cl: ПТ | KAVALDi
- tweak: Изменены слоты для ролей на карте Nox | инженер[2->4], учёный[2->3], доктор[1->2] стажёр[3->5], зек [3->10]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Балансировка**
  * Скорректированы уровни укомплектования и взаимозависимости рабочих ролей на Планете-тюрьме для оптимизации управления персоналом.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->