### PR TITLE
Small tweak: CrewAlert

### DIFF
--- a/Content.Server/_Sunrise/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.Alert.cs
+++ b/Content.Server/_Sunrise/Medical/CrewMonitoring/CrewMonitoringConsoleSystem.Alert.cs
@@ -1,5 +1,4 @@
 using Content.Server.Power.EntitySystems;
-using Content.Shared.Ghost;
 using Content.Shared.Medical.CrewMonitoring;
 using Content.Shared.Morgue.Components;
 using Content.Shared.Power.Components;
@@ -97,20 +96,21 @@ public sealed partial class CrewMonitoringConsoleSystem
 
     private void AddToggleVerb(Entity<CrewMonitoringCorpseAlertComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
     {
+        if (!ent.Comp.ShowToggleVerb)
+            return;
+
         if (!args.CanInteract || !args.CanAccess)
             return;
 
-        if (TryComp<GhostComponent>(args.User, out var ghost) && ghost.CanGhostInteract)
-            return;
-
-        InteractionVerb verb = new();
-
-        verb.Text = _loc.GetString(ent.Comp.DoCorpseAlert
+        var text = _loc.GetString(ent.Comp.DoCorpseAlert
             ? "item-toggle-deactivate-alert"
             : "item-toggle-activate-alert");
 
-        verb.Act = () => ToggleAlert(ent);
-        args.Verbs.Add(verb);
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = text,
+            Act = () => ToggleAlert(ent),
+        });
     }
 
     public void ToggleAlert(Entity<CrewMonitoringCorpseAlertComponent> ent)

--- a/Content.Shared/_Sunrise/Medical/CrewMonitoring/CrewMonitoringCorpseAlertComponent.cs
+++ b/Content.Shared/_Sunrise/Medical/CrewMonitoring/CrewMonitoringCorpseAlertComponent.cs
@@ -16,6 +16,12 @@ public sealed partial class CrewMonitoringCorpseAlertComponent : Component
     public bool DoCorpseAlert = false;
 
     /// <summary>
+    ///     Определяет, отображается ли verb для переключения оповещения.
+    /// </summary>
+    [DataField]
+    public bool ShowToggleVerb = true;
+
+    /// <summary>
     ///     Следующее время, когда можно проигрывать оповещение о падших с сенсорами.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -90,6 +90,10 @@
     followEntity: true
   - type: CargoOrderConsole
   - type: CrewMonitoringConsole
+    # Sunrise - Start отключаем verb
+  - type: CrewMonitoringCorpseAlert
+    showToggleVerb: false
+    # Sunrise - End
   - type: GeneralStationRecordConsole
     canDeleteEntries: true
   - type: DeviceNetwork


### PR DESCRIPTION


## Кратное описание
Добавил проверку, является ли сущность призраком. Ему добавлялась бесполезная кнопка.

## Медиа(Видео/Скриншоты)
Кнопку которую убрал 


<img width="1003" height="255" alt="grafik" src="https://github.com/user-attachments/assets/770923e8-6c7a-412e-8529-751d6f0827ea" />


**Changelog**

:cl: Orvex07

- remove: Удалена кнопка взаимодействия "Активировать тревогу" у админ призрака. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Система мониторинга экипажа — корректно обрабатывается доступ к переключению оповещений; предотвращены некорректные взаимодействия для специальных наблюдателей.

* **Новые возможности**
  * Добавлена настройка видимости команды переключения оповещения о трупах; по умолчанию доступна, но может быть скрыта для отдельных профилей (например, для админ‑наблюдателей).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->