### PR TITLE
CVar значения для DeltaP 

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -25,7 +25,12 @@ public partial class AtmosphereSystem
         float maxComponent = 0; // moles of the dominant gas
         for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
         {
-            basePrice += mixture.Moles[i] * GetGas(i).PricePerMole;
+            // Sunrise edit start - gas price CVar modifiers
+            var gas = GetGas(i);
+            var modifier = GetModifier(gas.ID);
+            basePrice += mixture.Moles[i] * gas.PricePerMole * modifier;
+            // Sunrise edit end
+
             totalMoles += mixture.Moles[i];
             maxComponent = Math.Max(maxComponent, mixture.Moles[i]);
         }

--- a/Content.Server/Atmos/EntitySystems/DeltaPressureSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/DeltaPressureSystem.cs
@@ -25,7 +25,12 @@ public sealed partial class DeltaPressureSystem : SharedDeltaPressureSystem
         SubscribeLocalEvent<DeltaPressureComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<DeltaPressureComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<DeltaPressureComponent, GridUidChangedEvent>(OnGridChanged);
+
+        // Sunrise-edit - Configurable DeltaP in CVars
+        AfterInit();
     }
+
+    partial void AfterInit(); // Sunrise-edit - Configurable DeltaP in CVars
 
     private void OnComponentInit(Entity<DeltaPressureComponent> ent, ref ComponentInit args)
     {

--- a/Content.Server/_Sunrise/Atmos/EntitySystems/AtmosphereSystem.CCVars.cs
+++ b/Content.Server/_Sunrise/Atmos/EntitySystems/AtmosphereSystem.CCVars.cs
@@ -1,0 +1,63 @@
+using Content.Shared._Sunrise.SunriseCCVars;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+public enum GasIds
+{
+    Tritium,
+    NitrousOxide,
+    Frezon,
+    BZ,
+    Healium,
+    Nitrium
+}
+
+public partial class AtmosphereSystem
+{
+    private float _defaultGasPriceModifier;
+    private float _gasPriceModifierTritium;
+    private float _gasPriceModifierNitrousOxide;
+    private float _gasPriceModifierFrezon;
+    private float _gasPriceModifierBZ;
+    private float _gasPriceModifierHealium;
+    private float _gasPriceModifierNitrium;
+
+    private bool _subscribed = false;
+
+    public void Subscribe()
+    {
+        if (_subscribed)
+        {
+            return;
+        }
+
+        _cfg.OnValueChanged(SunriseCCVars.DefaultGasPriceModifier, (value) => _defaultGasPriceModifier = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.GasPriceModifierTritium, (value) => _gasPriceModifierTritium = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.GasPriceModifierNitrousOxide, (value) => _gasPriceModifierNitrousOxide = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.GasPriceModifierFrezon, (value) => _gasPriceModifierFrezon = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.GasPriceModifierBZ, (value) => _gasPriceModifierBZ = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.GasPriceModifierHealium, (value) => _gasPriceModifierHealium = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.GasPriceModifierNitrium, (value) => _gasPriceModifierNitrium = value, true);
+
+        _subscribed = true;
+    }
+
+    public float GetModifier(string id)
+    {
+        Subscribe();
+
+        if (!Enum.TryParse<GasIds>(id, out var gasId))
+            return _defaultGasPriceModifier;
+
+        return gasId switch
+        {
+            GasIds.Tritium => _gasPriceModifierTritium,
+            GasIds.NitrousOxide => _gasPriceModifierNitrousOxide,
+            GasIds.Frezon => _gasPriceModifierFrezon,
+            GasIds.BZ => _gasPriceModifierBZ,
+            GasIds.Healium => _gasPriceModifierHealium,
+            GasIds.Nitrium => _gasPriceModifierNitrium,
+            _ => _defaultGasPriceModifier,
+        };
+    }
+}

--- a/Content.Server/_Sunrise/Atmos/EntitySystems/DeltaPressureSystem.cs
+++ b/Content.Server/_Sunrise/Atmos/EntitySystems/DeltaPressureSystem.cs
@@ -1,0 +1,83 @@
+using Content.Shared._Sunrise.SunriseCCVars;
+using Content.Shared.Atmos.Components;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+public enum WindowID
+{
+    // Reinforced plasma windows
+    PlasmaReinforcedWindowDirectional,
+    ReinforcedPlasmaWindow,
+    ReinforcedPlasmaWindowDiagonal,
+
+    // Reinforced windows
+    WindowReinforcedDirectional,
+    ReinforcedWindow,
+    ReinforcedWindowDiagonal
+}
+
+// This system allows to override values from `deltapressure.yml` without modifying prototypes
+public partial class DeltaPressureSystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+
+    private float _minPReinforcedPlasma;
+    private float _deltaPReinforcedPlasma;
+
+    private float _minPReinforcedPlasmaQuarter;
+    private float _deltaPReinforcedPlasmaQuarter;
+
+    private float _minPReinforced;
+    private float _deltaPReinforced;
+
+    private float _minPReinforcedQuarter;
+    private float _deltaPReinforcedQuarter;
+
+    partial void AfterInit()
+    {
+        _cfg.OnValueChanged(SunriseCCVars.MinPReinforcedPlasma, (value) => _minPReinforcedPlasma = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.DeltaPReinforcedPlasma, (value) => _deltaPReinforcedPlasma = value, true);
+
+        _cfg.OnValueChanged(SunriseCCVars.MinPReinforcedPlasmaQuarter, (value) => _minPReinforcedPlasmaQuarter = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.DeltaPReinforcedPlasmaQuarter, (value) => _deltaPReinforcedPlasmaQuarter = value, true);
+
+        _cfg.OnValueChanged(SunriseCCVars.MinPReinforced, (value) => _minPReinforced = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.DeltaPReinforced, (value) => _deltaPReinforced = value, true);
+
+        _cfg.OnValueChanged(SunriseCCVars.MinPReinforcedQuarter, (value) => _minPReinforcedQuarter = value, true);
+        _cfg.OnValueChanged(SunriseCCVars.DeltaPReinforcedQuarter, (value) => _deltaPReinforcedQuarter = value, true);
+
+        SubscribeLocalEvent<DeltaPressureComponent, ComponentStartup>(OnDeltaPressureComponentStartup);
+    }
+
+    private void OnDeltaPressureComponentStartup(Entity<DeltaPressureComponent> ent, ref ComponentStartup args)
+    {
+        Override(ent, ref args);
+    }
+
+    private bool Override(Entity<DeltaPressureComponent> ent, ref ComponentStartup args)
+    {
+        TryPrototype(ent, out var proto);
+
+        if (proto is null || !Enum.TryParse<WindowID>(proto.ID, out var windowProtoID))
+            return false;
+
+        return windowProtoID switch
+        {
+            WindowID.PlasmaReinforcedWindowDirectional => SetPressure(ent, _minPReinforcedPlasmaQuarter, _deltaPReinforcedPlasmaQuarter),
+            WindowID.ReinforcedPlasmaWindow or WindowID.ReinforcedPlasmaWindowDiagonal => SetPressure(ent, _minPReinforcedPlasma, _deltaPReinforcedPlasma),
+            WindowID.WindowReinforcedDirectional => SetPressure(ent, _minPReinforcedQuarter, _deltaPReinforcedQuarter),
+            WindowID.ReinforcedWindow or WindowID.ReinforcedWindowDiagonal => SetPressure(ent, _minPReinforced, _deltaPReinforced),
+            _ => false,
+        };
+    }
+
+    private static bool SetPressure(Entity<DeltaPressureComponent> ent, float minP, float deltaP)
+    {
+        ent.Comp.MinPressure = minP;
+        ent.Comp.MinPressureDelta = deltaP;
+        return true;
+    }
+}

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Atmos.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Atmos.cs
@@ -1,0 +1,32 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Sunrise.SunriseCCVars;
+
+public sealed partial class SunriseCCVars
+{
+    /// <summary>
+    /// These variables control modifications of various gas prices. If gas has no specified
+    /// modifier here, it will use default price from prototype
+    /// </summary>
+
+    public static readonly CVarDef<float> DefaultGasPriceModifier =
+        CVarDef.Create("atmos.gas_price_modifier_default", 1f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierTritium =
+        CVarDef.Create("atmos.gas_price_modifier_tritium", 0.016f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierNitrousOxide =
+        CVarDef.Create("atmos.gas_price_modifier_nitrous_oxide", 2f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierFrezon =
+        CVarDef.Create("atmos.gas_price_modifier_frezon", 0.25f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierBZ =
+        CVarDef.Create("atmos.gas_price_modifier_bz", 1f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierHealium =
+        CVarDef.Create("atmos.gas_price_modifier_healium", 1f, CVar.SERVER);
+
+    public static readonly CVarDef<float> GasPriceModifierNitrium =
+        CVarDef.Create("atmos.gas_price_modifier_nitrium", 1f, CVar.SERVER);
+}

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Atmos.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Atmos.cs
@@ -29,4 +29,32 @@ public sealed partial class SunriseCCVars
 
     public static readonly CVarDef<float> GasPriceModifierNitrium =
         CVarDef.Create("atmos.gas_price_modifier_nitrium", 1f, CVar.SERVER);
+
+    /// <summary>
+    /// DeltaP threshold overrides for pressure window shattering
+    /// </summary>
+
+    public static readonly CVarDef<float> MinPReinforcedPlasma =
+        CVarDef.Create("atmos.reinforced_plasma_window_minP", 150000f, CVar.SERVER);
+
+    public static readonly CVarDef<float> DeltaPReinforcedPlasma =
+        CVarDef.Create("atmos.reinforced_plasma_window_deltaP", 100000f, CVar.SERVER);
+
+    public static readonly CVarDef<float> MinPReinforcedPlasmaQuarter =
+        CVarDef.Create("atmos.reinforced_plasma_window_quarter_minP", 37500f, CVar.SERVER);
+
+    public static readonly CVarDef<float> DeltaPReinforcedPlasmaQuarter =
+        CVarDef.Create("atmos.reinforced_plasma_window_quarter_deltaP", 25000f, CVar.SERVER);
+
+    public static readonly CVarDef<float> MinPReinforced =
+        CVarDef.Create("atmos.reinforced_window_minP", 15000f, CVar.SERVER);
+
+    public static readonly CVarDef<float> DeltaPReinforced =
+        CVarDef.Create("atmos.reinforced_window_deltaP", 10000f, CVar.SERVER);
+
+    public static readonly CVarDef<float> MinPReinforcedQuarter =
+        CVarDef.Create("atmos.reinforced_window_quarter_minP", 3750f, CVar.SERVER);
+
+    public static readonly CVarDef<float> DeltaPReinforcedQuarter =
+        CVarDef.Create("atmos.reinforced_window_quarter_deltaP", 2500f, CVar.SERVER);
 }

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 0.04 #Sunrise-edit
+  pricePerMole: 2.5
 
 - type: gas
   id: WaterVapor
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 0.5 # Sunrise-Edit
+  pricePerMole: 0.1
 
 - type: gas
   id: Frezon
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 0.25 # Sunrise-Edit
+  pricePerMole: 1

--- a/Resources/Prototypes/_Sunrise/Atmospherics/gases.yml
+++ b/Resources/Prototypes/_Sunrise/Atmospherics/gases.yml
@@ -1,3 +1,6 @@
+# If you will add more custom gases here, consider adding CVars for
+# making it's price configurable -> _Sunrise\Atmos\EntitySystems\AtmosphereSystem.CCVars.cs
+
 - type: gas
   id: BZ
   name: gases-bz


### PR DESCRIPTION
Добавлены настройки DeltaP для некоторых видов окон в CVars. 

Merge-after [#3811](https://github.com/space-sunrise/sunrise-station/pull/3811)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления

* **Новые функции**
  * Добавлена возможность настройки цен на газы через конфигурационные переменные
  * Добавлена возможность настройки порогов давления для усиленных окон через конфигурационные переменные

* **Изменения**
  * Обновлены базовые цены на отдельные газы

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->