### PR TITLE
Отключение atmos.grid-impulse

### DIFF
--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -63,8 +63,9 @@ public sealed partial class CCVars
     ///     Whether explosive depressurization will cause the grid to gain an impulse.
     ///     Needs <see cref="MonstermosEqualization"/> and <see cref="MonstermosDepressurization"/> to be enabled to work.
     /// </summary>
+    // Sunrise FIXME: При включении вызывает исключение в ShuttleSystem.Impact из-за MeteorSystem при отключенном якоре
     public static readonly CVarDef<bool> AtmosGridImpulse =
-        CVarDef.Create("atmos.grid_impulse", true, CVar.SERVERONLY); // Sunrise-Edit
+        CVarDef.Create("atmos.grid_impulse", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     What fraction of air from a spaced tile escapes every tick.


### PR DESCRIPTION
Включение этого CVar при отключенном якоре приводит к цепной реакции коллизий с пристыкованными шаттлами, что вызывает самопроизвольную детонацию™ частей станции и шаттлов, а также вызывает исключения при некоторых взрывах. 

CVar надо будет включить после доработки механик коллизий с шаттлами и метеорами.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Изменения

* **Изменения конфигурации**
  * Значение параметра сеточной системы атмосферы изменено: сейчас функция отключена по умолчанию (раньше была включена). Это повлияет на поведение атмосферы при стандартных настройках сервера; для возврата прежнего поведения потребуется ручная активация параметра.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->