### PR TITLE
Фикс коллизий метеоров

### DIFF
--- a/Content.Server/Mining/MeteorSystem.cs
+++ b/Content.Server/Mining/MeteorSystem.cs
@@ -57,8 +57,8 @@ public sealed class MeteorSystem : EntitySystem
         var trueDamage = FixedPoint2.Min(maxMeteorDamage, threshold);
 
         var damage = component.DamageTypes * trueDamage;
-        _damageable.TryChangeDamage(args.OtherEntity, damage, true, origin: uid);
-        _damageable.TryChangeDamage(uid, damage);
+        _damageable.TryChangeDamage(args.OtherEntity, damage, true, origin: uid, ignoreVariance: true); // Sunrise-edit
+        _damageable.TryChangeDamage(uid, damage, ignoreVariance: true); // Sunrise-edit
 
         if (!TerminatingOrDeleted(args.OtherEntity))
             component.HitList.Add(args.OtherEntity);

--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random.Helpers;
+using Robust.Server.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
@@ -17,6 +18,7 @@ namespace Content.Server.StationEvents.Events;
 public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
 {
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly StationSystem _station = default!;
 
@@ -32,8 +34,7 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
         if (component.Announcement is { } locId)
             _chat.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(locId), playDefault: false, colorOverride: Color.Gold);
 
-        // Sunrise-Edit
-        // _audio.PlayGlobal(component.AnnouncementSound, allPlayersInGame, true);
+        _audio.PlayGlobal(component.AnnouncementSound, allPlayersInGame, true);
     }
 
     protected override void ActiveTick(EntityUid uid, MeteorSwarmComponent component, GameRuleComponent gameRule, float frameTime)

--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -63,8 +63,9 @@ public sealed partial class CCVars
     ///     Whether explosive depressurization will cause the grid to gain an impulse.
     ///     Needs <see cref="MonstermosEqualization"/> and <see cref="MonstermosDepressurization"/> to be enabled to work.
     /// </summary>
+    // Sunrise FIXME: При включении вызывает исключение в ShuttleSystem.Impact из-за MeteorSystem при отключенном якоре
     public static readonly CVarDef<bool> AtmosGridImpulse =
-        CVarDef.Create("atmos.grid_impulse", true, CVar.SERVERONLY); // Sunrise-Edit
+        CVarDef.Create("atmos.grid_impulse", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     What fraction of air from a spaced tile escapes every tick.


### PR DESCRIPTION
Убран DamageVariance для метеоров, что позволяет метеорам корректно взрываться при коллизии с обьектами.

Отключен CVar grid-impulse, так как метеоры создают разгерму, из-за чего при отключенном якоре `ShuttleSystem.Impact` кидает исключение, а также вызывает цепную реакцию со взрывом шаттлов. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Восстановлен звуковой эффект объявления о метеорном рое. Теперь все игроки на сервере будут слышать оповещение о прибытии метеорного роя.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->