### PR TITLE
Простреливаемые ящики

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -112,6 +112,8 @@
     stateDoorClosed: generic_door
   - type: StaticPrice
     price: 75
+  - type: Pierceable # Sunrise-edit - прострел ящиков
+    level: Wood
 
 # steel closet base (that can be constructed/deconstructed)
 - type: entity
@@ -315,3 +317,5 @@
     stateDoorOpen: base
     stateDoorClosed: door
   - type: LockVisuals
+  - type: Pierceable # Sunrise-edit - прострел ящиков
+    level: Wood

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -79,6 +79,8 @@
   components:
   - type: Weldable
   - type: ResistLocker
+  - type: Pierceable # Sunrise-edit - прострел ящиков
+    level: Wood
 
 - type: entity
   parent: CrateBaseWeldable

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -343,6 +343,9 @@
     sprite: Structures/Storage/Crates/weapon.rsi
   - type: AccessReader
     access: [["Armory"]]
+  - type: Pierceable # Sunrise-edit - прострел ящиков
+    level: Metal
+
 
 - type: entity
   parent: [ CrateBaseSecure, BaseSecurityContraband ]


### PR DESCRIPTION
Добавлен прострел <del>на мираже</del> ящиков для повышения <del>баланса</del> реализма. 

Ящики тонкие и могут быть прострелены боевыми патронами, бронированные оружейные ящики простреливаются хуже. 

![crate](https://github.com/user-attachments/assets/c0e8b0f0-2a0e-464c-9f11-c1f04bc9a788)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storage containers now have variable piercing resistance based on their type. Weapon-secure crates require metal to pierce, while standard crates and closets can be pierced with wood-level tools, adding new interaction options for players engaging with storage structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->