### PR TITLE
щит возвращён в аплинк придателей

### DIFF
--- a/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/uplink_catalog.yml
@@ -2929,6 +2929,7 @@
           - LoneOpsUplink
           - AssaultOpsUplink
 
+- type: listing
   id: UplinkCornivoreGloves
   name: uplink-cornivoregloves-name
   description: uplink-cornivoregloves-desc


### PR DESCRIPTION
потому что он там должен быть.,
:cl: Fooksy2304
- fix: Синдикат восстановил поставки энергощита предателям.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * В каталог апллинка добавлен новый предмет — энергетический щит для предателей. Стоимость: 6 телекристаллов (возможная скидка до 3). Отнесён к вооружению и исключён из продажи в специальных наборах апллинка (NukeOps, LoneOps, AssaultOps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->