### PR TITLE
уменьшен урон Арахнидам

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -62,7 +62,7 @@
       path: /Audio/Effects/bite.ogg
     damage:
       types:
-        Piercing: 15 # Sunrise-Edit
+        Piercing: 5
   # Visual & Audio
   - type: DamageVisuals
     damageOverlayGroups:


### PR DESCRIPTION
## Кратное описание
Урон арахнидов уменьшен с 15 до 5

## По какой причине
Никакая раса не должна иметь больше 9 урона за удар. Они смогут ломать стены голыми руками и их будет трудно держать в заключении. Так же создавать урон копья в руке сомнительная идея. А ещё меня Junter Fox попросил


:cl: Kinar_7
- tweak: Урон арахнидов уменьшен с 15 до 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Скорректирован баланс урона: урон от прокола для оружия ближнего боя вида арахнид уменьшен с 15 до 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->