### PR TITLE
прыжки нианам и воксам

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -44,6 +44,7 @@
       reagents:
       - ReagentId: InsectBlood
         Quantity: 300
+# Sunrise edit start
   - type: JumpAbility
     action: ActionVulpkaninGravityJump
     canCollide: true
@@ -54,6 +55,7 @@
         pitch: 1.33
         volume: -5
         variation: 0.05
+# Sunrise edit end
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -96,6 +96,7 @@
         color: "#7a8bf2"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
+# Sunrise edit start
   - type: JumpAbility
     action: ActionVulpkaninGravityJump
     canCollide: true
@@ -106,6 +107,7 @@
         pitch: 1.33
         volume: -5
         variation: 0.05
+# Sunrise edit end
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
_Я упал со стула с первым таким ПРом, так что пишу снова..._
Нианы - это буквально большие антропоморфные бабочки (правда без третьей пары лап), а воксы - по факту, тоже своего рода птицы, как и резоми. Летать они не могут, но прыгать будто бы должны уметь.
## По какой причине
ЛоР и ребаланс откровенно пососных в плане механа рас. Должны же у них быть преимущества. Это конечно не всё, что хотелось бы, но для остального надо спрайты выпросить.

## Summary

:cl: seemah
- add: Добавлены прыжки нианам и воксам.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новые возможности
- Добавлена механика прыжка для видов мотыльков и воксов. Эти мобы теперь способны совершать управляемые прыжки на расстояние до трёх клеток с соответствующими звуковыми эффектами. Прыжки позволяют повысить тактическую маневренность этих существ в боевых ситуациях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->