### PR TITLE
Все спавны боргов с LateJoin

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -289,7 +289,7 @@
     job_id: Borg
   # Sunrise-start
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   # Sunrise-end
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Sunrise/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Markers/Spawners/jobs.yml
@@ -198,7 +198,7 @@
   - type: SpawnPoint
     job_id: ClownBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green
@@ -215,7 +215,7 @@
   - type: SpawnPoint
     job_id: EngineerBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green
@@ -232,7 +232,7 @@
   - type: SpawnPoint
     job_id: JanitorBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green
@@ -249,7 +249,7 @@
   - type: SpawnPoint
     job_id: MedicalBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green
@@ -266,7 +266,7 @@
   - type: SpawnPoint
     job_id: MiningBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green
@@ -283,7 +283,7 @@
   - type: SpawnPoint
     job_id: PeaceBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green
@@ -300,7 +300,7 @@
   - type: SpawnPoint
     job_id: SecurityBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green
@@ -317,7 +317,7 @@
   - type: SpawnPoint
     job_id: ServiceBorg
   - type: PreferredSpawn
-    preferredSpawnTypes: [ Job, LateJoin ]
+    preferredSpawnTypes: [ Job ]
   - type: Sprite
     layers:
     - state: green


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Лейтджоин спавн боргов - чтобы они не спавнились в криосне.
Предлагаю сделать изменением прототипов текущих спавнеров чтобы не пришлось маппить одно и то же дважды.
Если стоит создать отдельные спавнеры для позднего присоединения и поместить их к другим подобным спавнерам (

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Спавн боргов в криосне при позднем присоединении несколько нелогичен и его можно банально перенести на раундстартовые спавнеры без последствий.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="1280" height="720" alt="2026-2-17_18 43 28" src="https://github.com/user-attachments/assets/17e09301-0786-4d50-9154-17a5939219c0" />
<img width="1280" height="720" alt="2026-2-17_18 48 04" src="https://github.com/user-attachments/assets/97fde49d-9a34-435a-933b-cc04b0109e12" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.
-->

:cl: Miolo
- tweak: При позднем присоединении боргом вас будет спавнить как в начале раунда.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Обновлены параметры появления для точек спавна Бргов с добавлением предпочтений распределения. Теперь система правильнее определяет назначение этих точек спавна для игроков с установленными должностями и поздно присоединившихся участников.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->