### PR TITLE
крафт Красного фосфора через Химию

### DIFF
--- a/Resources/Prototypes/_Sunrise/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Reactions/fun.yml
@@ -5,11 +5,11 @@
   minTemp: 500
   reactants:
     Phosphorus:
-      amount: 2
+      amount: 4
     Hydrogen:
-      amount: 1
+      amount: 2
     Ethanol:
-      amount: 1
+      amount: 2
   effects:
-    - !type:CreateEntityReactionEffect
+    - !type:SpawnEntity
       entity: CrushedPhosphorus1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Добавлена хим реакция для создания красного фосфора ( пороха для бедных) 
на кувшин в 200u фосфора выйдет 100 единиц порошка примерно 50-80 самодельных патронов
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: KaiserMaus
- add: Добавлена химическая реакция для создания порошка красного фосфора. Смешайте 2 водорода, 2 этанола и 4 фосфора и после нагрейте.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новые возможности

* Добавлена новая химическая реакция, позволяющая комбинировать фосфор, водород и этанол при температуре 500°C для создания нового материала.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->