### PR TITLE
Исправление: Возвращения очки в лодаут и доступы Офицеру "Синий Щит"

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -17,17 +17,6 @@
       department: Cargo
       time: 10h # 10 hours of being a space trucker
 
-# sunrise-start
-- type: loadoutEffectGroup
-  id: CheapSunglassesTimer
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:DepartmentTimeRequirement
-      department: Civilian
-      time: 108000 #30 hours of bread cooking and Manly Dorf making
-# sunrise-end
-
 # Basic options
 # Glasses
 - type: loadout
@@ -53,18 +42,3 @@
     proto: JensenTimer
   equipment:
     eyes: ClothingEyesGlassesJensen
-
-# sunrise-start
-- type: loadout
-  id: GlassesCheapSunglasses
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: CheapSunglassesTimer
-  equipment:
-    eyes: ClothingEyesGlassesCheapSunglasses
-
-- type: loadout
-  id: GlassesStuttering
-  equipment:
-    eyes: ClothingEyesStuttering
-# sunrise-end

--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -53,3 +53,18 @@
     proto: JensenTimer
   equipment:
     eyes: ClothingEyesGlassesJensen
+
+# sunrise-start
+- type: loadout
+  id: GlassesCheapSunglasses
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: CheapSunglassesTimer
+  equipment:
+    eyes: ClothingEyesGlassesCheapSunglasses
+
+- type: loadout
+  id: GlassesStuttering
+  equipment:
+    eyes: ClothingEyesStuttering
+# sunrise-end

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -86,6 +86,10 @@
   - Glasses
   - GlassesJamjar
   - GlassesJensen
+  # Sunrise-start
+  - GlassesCheapSunglasses
+  - GlassesStuttering
+  # Sunrise-end
 
 - type: loadoutGroup
   id: GroupTankHarness

--- a/Resources/Prototypes/_Sunrise/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/Miscellaneous/glasses.yml
@@ -1,0 +1,21 @@
+- type: loadoutEffectGroup
+  id: CheapSunglassesTimer
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 108000 #30 hours of bread cooking and Manly Dorf making
+
+- type: loadout
+  id: GlassesCheapSunglasses
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: CheapSunglassesTimer
+  equipment:
+    eyes: ClothingEyesGlassesCheapSunglasses
+
+- type: loadout
+  id: GlassesStuttering
+  equipment:
+    eyes: ClothingEyesStuttering

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_officer.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_officer.yml
@@ -65,3 +65,4 @@
     eyes: ClothingEyesGlassesBlueShield
     outerClothing: ClothingOuterArmorBlueShield
     gloves: ClothingHandsGlovesCombat
+    

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_officer.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_officer.yml
@@ -33,7 +33,6 @@
     - Brig
     - Cargo
     - Atmospherics
-    - Cargo
     - Medical
     - BlueShield
     - Cryogenics

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_officer.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Blueshield/blueshield_officer.yml
@@ -36,6 +36,10 @@
     - Cargo
     - Medical
     - BlueShield
+    - Cryogenics
+    - Lawyer
+    - Barber
+    - Mining
   special:
     - !type:AddImplantSpecial
       implants: [ MindShieldImplant ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
В каком-то PRе задели очки и они пропали с лодаута именно неловки очки и дешёвые солнце защитные очки. Добавляя сами очки в лодаут в разделе очки, для получения остается наиграется в разделе сервиса 30ч для получения доступа, неловкие доступны сразу.
Добавления доступов для офицеру СЩ, именно крио, юридический, шахтер, парикмахер  
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
предложка с очками взята с Дискорда Ласта (https://discord.com/channels/1253315855731916821/1474843852673126684)
Добавления доступов для синего щита уже моя идея исправления на получения доступов
Офицер "Синий Щит" нуждается в некоторых доступах, ведь он сам не может попасть в отдел юридический, и АВД тоже входит в защиту по СРП(Если брать вики именно ласта), а также если в раунде был ОСЩ и он ушел в крио (пример с ключами шифрования СЩ) то новый прибывший без получения доступа или по просьбе СБ/Ком не может достать предмет.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="636" height="431" alt="image" src="https://github.com/user-attachments/assets/611e5d88-499f-4164-a487-1ec2a12c4596" />
<img width="545" height="547" alt="image" src="https://github.com/user-attachments/assets/7eef1429-9b4b-440d-a0c1-f613e3beffcb" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: BDSM_
- add: Возвращены дешёвые солнце защитные и неловкие очки в лодаут
- tweak: Офицер "Синий Щит" получил дополнительные доступы

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Добавлены варианты очков: дешёвые солнцезащитные и очки «заикание».
* **Исправления**
  * Устранено дублирование в правах доступа Blueshield.
* **Обновления прав доступа**
  * Офицерам Blueshield добавлен доступ к криогеникам, адвокату, парикмахерской и шахтам.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->