### PR TITLE
Фикс краша *дебага* при подогреве еды (#3940)

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -391,11 +391,7 @@ namespace Content.Server.Construction
 
                     if (tempEvent.Result is not null)
                         return tempEvent.Result.Value;
-                    // Sunrise-start
-                    // Фикс щиткода без валидации для HandleStep - чтобы не крашило в дебаге
-                    if (validation && (HasComp<InternalTemperatureComponent>(uid) || HasComp<TemperatureComponent>(uid)))
-                        return HandleResult.Validated;
-                    // Sunrise-end
+
                     // prefer using InternalTemperature since that's more accurate for cooking.
                     float temp;
                     if (TryComp<InternalTemperatureComponent>(uid, out var internalTemp))
@@ -414,7 +410,7 @@ namespace Content.Server.Construction
                     if ((!temperatureChangeStep.MinTemperature.HasValue || temp >= temperatureChangeStep.MinTemperature.Value) &&
                         (!temperatureChangeStep.MaxTemperature.HasValue || temp <= temperatureChangeStep.MaxTemperature.Value))
                     {
-                        return HandleResult.True;
+                        return validation ? HandleResult.Validated : HandleResult.True;
                     }
 
                     return HandleResult.False;
@@ -426,7 +422,7 @@ namespace Content.Server.Construction
                         break;
 
                     if (partAssemblyStep.Condition(uid, EntityManager))
-                        return HandleResult.True;
+                        return validation ? HandleResult.Validated : HandleResult.True;
                     return HandleResult.False;
                 }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Фикс немножко щиткода для исправления #3940.
Может не очень красиво, но по производительности и корректности - норм.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Чтобы не ломался ебучий дебаг когда греешь еду.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
увы (ну а что мне показать, всё пашет)

v з.ы. для игрунов ничего не меняется
**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Уточнена логика проверки валидации: на этапе валидации температурных и сборочных условий объекты теперь помечаются как валидные сразу, что повышает стабильность проверок и снижает вероятность лишних повторных проверок.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->