### PR TITLE
Фикс логов урона от оружия с хитсканом (#3660)

### DIFF
--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
@@ -1,15 +1,15 @@
 using Content.Shared.Damage.Systems;
-using Content.Shared.Database;
+using Content.Shared.Database; // Sunrise-edit
 using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Hitscan.Events;
-using Content.Shared.Administration.Logs;
+using Content.Shared.Administration.Logs; // Sunrise-edit
 
 namespace Content.Shared.Weapons.Hitscan.Systems;
 
 public sealed class HitscanBasicDamageSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damage = default!;
-    [Dependency] private readonly ISharedAdminLogManager _log = default!;
+    [Dependency] private readonly ISharedAdminLogManager _log = default!; // Sunrise-edit
 
     public override void Initialize()
     {
@@ -40,11 +40,13 @@ public sealed class HitscanBasicDamageSystem : EntitySystem
         if (damageDealt == null)
             return;
 
+        // Sunrise-start
         _log.Add(
             LogType.Damaged,
             $"{ToPrettyString(args.Data.Shooter):user} damaged {ToPrettyString(args.Data.HitEntity):target}"
                 + $" using {ToPrettyString(args.Data.Gun):entity} by {damageDealt.GetTotal():0.##}."
         );
+        // Sunrise-end
 
         var damageEvent = new HitscanDamageDealtEvent
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->
fixes: #3660

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Исправить неприятный баг для администрации, которая не может определить урон, нанесённый оружием, использующим хитскан для пуль.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="865" height="489" alt="image" src="https://github.com/user-attachments/assets/c653afbf-b8d1-445e-8830-3dc3c56b5d4b" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Служебные изменения**
  * Добавлено административное логирование событий попаданий: в журнал теперь записываются стрелок, цель, оружие и величина нанесённого урона; записи создаются только при фактическом нанесении урона.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->