### PR TITLE
Проверка поля зрения для эмоутов панельки

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -942,6 +942,15 @@ public sealed partial class ChatSystem : SharedChatSystem
             var entRange = MessageRangeCheck(session, data, range);
             if (entRange == MessageRangeCheckResult.Disallowed)
                 continue;
+            // Sunrise-start
+            // Проверка на наличие видимости для эмоутов
+            if (
+                channel == ChatChannel.Emotes
+                && session.AttachedEntity is not null
+                && !_examineSystem.InRangeUnOccluded(source, session.AttachedEntity.Value, VoiceRange)
+            )
+                continue;
+            // Sunrise-end
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
             _chatManager.ChatMessageToOne(channel, message, wrappedMessage, source, entHideChat, session.Channel, author: author, colorOverride: color);
         }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -946,9 +946,9 @@ public sealed partial class ChatSystem : SharedChatSystem
             // Проверка на наличие прямой видимости для эмоутов
             if (channel == ChatChannel.Emotes)
             {
-                var ev = new VisibilityCheckEvent(source, session.AttachedEntity, VoiceRange);
-                RaiseLocalEvent(ev);
-                if (ev.Cancelled)
+                var ev = new EmoteVisibilityCheckEvent(source, session.AttachedEntity, VoiceRange);
+                RaiseLocalEvent(ref ev);
+                if (!ev.Visible)
                     continue;
             }
             // Sunrise-end

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -943,13 +943,14 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (entRange == MessageRangeCheckResult.Disallowed)
                 continue;
             // Sunrise-start
-            // Проверка на наличие видимости для эмоутов
-            if (
-                channel == ChatChannel.Emotes
-                && session.AttachedEntity is not null
-                && !_examineSystem.InRangeUnOccluded(source, session.AttachedEntity.Value, VoiceRange)
-            )
-                continue;
+            // Проверка на наличие прямой видимости для эмоутов
+            if (channel == ChatChannel.Emotes)
+            {
+                var ev = new VisibilityCheckEvent(source, session.AttachedEntity, VoiceRange);
+                RaiseLocalEvent(ev);
+                if (ev.Cancelled)
+                    continue;
+            }
             // Sunrise-end
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
             _chatManager.ChatMessageToOne(channel, message, wrappedMessage, source, entHideChat, session.Channel, author: author, colorOverride: color);

--- a/Content.Server/_Sunrise/Chat/VisibilityCheckEvent.cs
+++ b/Content.Server/_Sunrise/Chat/VisibilityCheckEvent.cs
@@ -1,0 +1,15 @@
+namespace Content.Server._Sunrise.Chat;
+
+public sealed class VisibilityCheckEvent : CancellableEntityEventArgs
+{
+    public EntityUid Source { get; }
+    public EntityUid? Target { get; }
+    public float Range { get; }
+
+    public VisibilityCheckEvent(EntityUid source, EntityUid? target, float range)
+    {
+        Source = source;
+        Target = target;
+        Range = range;
+    }
+}

--- a/Content.Server/_Sunrise/Chat/VisibilityCheckEvent.cs
+++ b/Content.Server/_Sunrise/Chat/VisibilityCheckEvent.cs
@@ -1,15 +1,18 @@
+using NetCord;
 namespace Content.Server._Sunrise.Chat;
 
-public sealed class VisibilityCheckEvent : CancellableEntityEventArgs
+[ByRefEvent]
+public struct EmoteVisibilityCheckEvent(EntityUid source, EntityUid? target, float range)
 {
-    public EntityUid Source { get; }
-    public EntityUid? Target { get; }
-    public float Range { get; }
+    [DataField]
+    public EntityUid Source { get; } = source;
 
-    public VisibilityCheckEvent(EntityUid source, EntityUid? target, float range)
-    {
-        Source = source;
-        Target = target;
-        Range = range;
-    }
+    [DataField]
+    public EntityUid? Target { get; } = target;
+
+    [DataField]
+    public float Range { get; } = range;
+
+    [DataField]
+    public bool Visible { get; set; } = true;
 }

--- a/Content.Server/_Sunrise/Chat/VisibilityCheckSystem.cs
+++ b/Content.Server/_Sunrise/Chat/VisibilityCheckSystem.cs
@@ -2,27 +2,27 @@ using Content.Server.Examine;
 
 namespace Content.Server._Sunrise.Chat;
 
-public sealed class CheckVisibilitySystem : EntitySystem
+public sealed class EmoteVisibilityCheckSystem : EntitySystem
 {
     [Dependency] private readonly ExamineSystem _examineSystem = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<VisibilityCheckEvent>(HandleVisibilityCheck);
+        SubscribeLocalEvent<EmoteVisibilityCheckEvent>(HandleVisibilityCheck);
     }
 
-    private void HandleVisibilityCheck(VisibilityCheckEvent ev)
+    private void HandleVisibilityCheck(ref EmoteVisibilityCheckEvent ev)
     {
         if (ev.Target is null)
         {
-            ev.Cancel();
+            ev.Visible = false;
             return;
         }
 
         if (!_examineSystem.InRangeUnOccluded(ev.Source, ev.Target.Value, ev.Range))
         {
-            ev.Cancel();
+            ev.Visible = false;
             return;
         }
     }

--- a/Content.Server/_Sunrise/Chat/VisibilityCheckSystem.cs
+++ b/Content.Server/_Sunrise/Chat/VisibilityCheckSystem.cs
@@ -1,0 +1,29 @@
+using Content.Server.Examine;
+
+namespace Content.Server._Sunrise.Chat;
+
+public sealed class CheckVisibilitySystem : EntitySystem
+{
+    [Dependency] private readonly ExamineSystem _examineSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<VisibilityCheckEvent>(HandleVisibilityCheck);
+    }
+
+    private void HandleVisibilityCheck(VisibilityCheckEvent ev)
+    {
+        if (ev.Target is null)
+        {
+            ev.Cancel();
+            return;
+        }
+
+        if (!_examineSystem.InRangeUnOccluded(ev.Source, ev.Target.Value, ev.Range))
+        {
+            ev.Cancel();
+            return;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
#358 - сделать так, чтобы не было видно эмоутов панельки если они вне поля зрения.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
- нереалистично
- мета
- на ласте очень надо

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
Если попросите - сделаю видик, а так тут всё понятно я думаю

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.
-->

:cl: Miolo
- fix: Теперь эмоции за препятствиями из панели взаимодействий теперь не будут видны в чате.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Система эмотов в радиусе голоса теперь учитывает прямую видимость: эмоты доставляются только тем игрокам, которые находятся в прямой видимости от источника (без препятствий).

* **Новые возможности**
  * Внедрена проверка видимости для голосовых эмотов, повышающая реализм и предотвращающая доставку эмотов через стены и другие преграды.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->