### PR TITLE
убрал таймер из BasicStationEventScheduler

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -577,12 +577,6 @@
   parent: BaseGameRule
   components:
   - type: BasicStationEventScheduler
-    # Sunrise-Start
-    minimumTimeUntilFirstEvent: 600 # 10 mins
-    minMaxEventTiming:
-      min: 600 # 10 mins
-      max: 900 # 15 mins
-    # Sunrise-End
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 


### PR DESCRIPTION
## Кратное описание
Убрал 15 минутный таймер между ивентами 

## По какой причине
1) В игре уже есть таймер на не дающей ей создавать слишком много ивентов
<img width="625" height="200" alt="image" src="https://github.com/user-attachments/assets/1d1d3a79-a745-4a14-b3f6-1bfb32d7c6f3" />

2) Повысить динамику секрета, что бы он меньше напоминал Гриншифт. 

3) Из-за 2 таймеров, между ивентами могло пройти 25-30 минут. Что очень и очень много



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Чистка кода**
  * Удалены конфигурационные параметры временных интервалов из планировщика событий станции. Система теперь работает с упрощённой конфигурацией правил игры без дополнительных ограничений по времени срабатывания событий.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->