### PR TITLE
Фикс отображения урона для хитскан боеприпасов

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
@@ -4,6 +4,7 @@ using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Hitscan.Components; // Sunrise-edit
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
@@ -63,6 +64,19 @@ public abstract partial class SharedGunSystem
                 return p.Damage * Damageable.UniversalProjectileDamageModifier;
             }
         }
+
+        // Sunrise-start
+        if (entityProto.Components
+            .TryGetValue(Factory.GetComponentName<HitscanBasicDamageComponent>(), out var hitscanProjectile))
+        {
+            var hitscanDamageComp = (HitscanBasicDamageComponent) hitscanProjectile.Component;
+
+            if (!hitscanDamageComp.Damage.Empty)
+            {
+                return hitscanDamageComp.Damage * Damageable.UniversalHitscanDamageModifier;
+            }
+        }
+        // Sunrise-end
 
         return null;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->
fixes #3807

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Фикс бага
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Баги - плохо
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="352" height="197" alt="image" src="https://github.com/user-attachments/assets/cd792112-52eb-4313-9312-64520a377afd" />
<img width="397" height="173" alt="image" src="https://github.com/user-attachments/assets/6bb2313c-7acd-4acf-ab68-7d3722064413" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Miolo
- fix: Исправлено отображение урона для множества боеприпасов.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления версии

* **Улучшения**
  * Добавлена поддержка универсального модификатора урона для hitscan-оружия, обеспечивающая более гибкий расчет урона при использовании разных типов огнестрельного оружия.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->