### PR TITLE
Нерф поджога топора синди (оффы сделали ужас)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -38,7 +38,7 @@
     quickEquip: false
     slots:
     - back
-    - suitStorage  # Sunrise-Fireaxe
+    - suitStorage  # Sunrise-Add
   - type: Tool
     qualities:
       - Prying
@@ -57,26 +57,10 @@
   parent: [BaseSyndicateContraband, FireAxe]
   description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
-  #Sunrise-start
+  - type: MeleeWeapon
+    wideAnimationRotation: 90
   - type: IgniteOnMeleeHit
     fireStacks: 1
-  - type: MeleeWeapon
-    wideAnimationRotation: 135
-    swingLeft: true
-    attackRate: 0.75
-    damage:
-      types:
-        Blunt: 5
-        Slash: 10
-        Structural: 10
-    soundHit:
-      collection: MetalThud
-  - type: IncreaseDamageOnWield
-    damage:
-      types:
-        Slash: 15
-        Structural: 50
-    #Sunrise-end
   - type: Sprite
     sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
     state: icon
@@ -85,4 +69,4 @@
     quickEquip: false
     slots:
     - back
-    - suitStorage  # Sunrise-Fireaxe
+    - suitStorage  # Sunrise-Add


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Откат 3-х стаков поджога топора до 1 как у оффов. Они усилили огонь и текущий вариант по тушке без брони наносит в районе 120 урона за 1 удар с учетом всех тиков от поджога, что пиздец.


## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Оффы видимо бафнули огонь, так что на 1 стаке в одной руке топор наносит в районе 30-35 урона за все тики и поджог стакается, 3 удара вводят в крит Сбшника если не потушится он, что ещё более менее.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Отрегулирована боевая эффективность огненного боевого топора — уменьшено количество стеков воспламенения, накладываемых при ударе (теперь 1 стек).
  * Убрано бонусное увеличение урона при экипировке топора.
  * Скорректирована ориентация анимации ближнего боя (широкая ротация 90°) и позиционирование визуальных слоёв для более корректного отображения.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->