### PR TITLE
fix belt sheath size

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -12,7 +12,11 @@
   - type: Clothing
     sprite: Clothing/Belt/sheath.rsi
   - type: Item
-    size: Ginormous
+# Sunrise-Start
+    size: Normal
+    shape:
+    - 0,0,0,6
+# Sunrise-End
   - type: ItemSlots
     slots:
       item:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Размер ножен для рапиры теперь как у ножен  синдиката.
<!-- Что вы предлагаете изменить с помощью своего PR? -->

## По какой причине
В issues Fish station предложили изменить размер ножен Капитана, на такой, какой у ножен Синдиката. Так как раньше ножны Капитана нельзя было сложить в рюкзак, а Синдиката можно. https://github.com/space-sunrise/fish-station/issues/209
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<img width="437" height="169" alt="Screenshot 2026-03-22 222530" src="https://github.com/user-attachments/assets/f48838de-0c6c-47f1-84f6-e3a13787954c" />
<img width="394" height="162" alt="Screenshot 2026-03-22 222534" src="https://github.com/user-attachments/assets/5a5d61f1-ed58-4b78-84cf-50fe1c43bbe4" />
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: Flaxor13
- tweak: Изменён размер ножен для сабли капитана до уровня ножен рапиры.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Откорректирован размер чехла ремня с огромного на нормальный.
  * Уточнены параметры формы чехла ремня для правильного отображения и взаимодействия в игре.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->