### PR TITLE
Забрал некоторые доступы у клоуна-киборга

### DIFF
--- a/Resources/Prototypes/_Sunrise/borg_types.yml
+++ b/Resources/Prototypes/_Sunrise/borg_types.yml
@@ -126,6 +126,22 @@
     pieProtoId: FoodPieBananaCream
   - type: TTS
     voice: NecoArcTwo
+  - type: Access
+    tags:
+    - Engineering
+    - Medical
+    - Salvage
+    - Cargo
+    - Research
+    - Service
+    - Maintenance
+    - External
+    - Janitor
+    - Theatre
+    - Bar
+    - Kitchen
+    - Chapel
+    - Hydroponics
 
   # Sounds
   footstepCollection:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
Убрал доступы у клоуна-киборга в командование, СБ, бриг, химию и атмос.

## По какой причине
А они ему нужны?
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**

:cl: seemah
- tweak: У клоуна-киборга изъяты доступы в бриг, СБ, хим. лабораторию, атмосферный отсек и на мост.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Обновления**
  * Клоун-боргу теперь предоставлены дополнительные права доступа по всем отделениям станции, включая инженерное дело, медицину, спасение, логистику, научные исследования, обслуживание и другие области.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->