### PR TITLE
Вернул ксеноморфам пол (дубль 2)

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
@@ -244,7 +244,7 @@
           32:
             sprite: Mobs/Species/Reptilian/displacement.rsi
             state: mask
-    displacements:
+    unsexedDisplacements:
       head:
         sizeMaps:
           32:
@@ -270,7 +270,7 @@
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
             state: outer
-      hardsuit:
+      hardsuit-body-normal:
         sizeMaps:
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
@@ -157,6 +157,16 @@
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
             state: shoes
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: outer
+      hardsuit:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: hardsuit
     displacements:
       jumpsuit:
         sizeMaps:
@@ -269,6 +279,16 @@
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
             state: shoes
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: outer
+      hardsuit:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: hardsuit
     displacements:
       jumpsuit:
         sizeMaps:

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/humanoid_xeno.yml
@@ -147,7 +147,22 @@
           32:
             sprite: Mobs/Species/Reptilian/displacement.rsi
             state: mask
+      socks:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: socks
+      shoes:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: shoes
     displacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: jumpsuit
       head:
         sizeMaps:
           32:
@@ -163,7 +178,7 @@
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
             state: shoes
-      socks-body-curved-small-muzzle:
+      socks:
         sizeMaps:
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
@@ -199,7 +214,7 @@
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
             state: outer
-      hardsuit-body-normal:
+      hardsuit:
         sizeMaps:
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
@@ -244,7 +259,22 @@
           32:
             sprite: Mobs/Species/Reptilian/displacement.rsi
             state: mask
-    unsexedDisplacements:
+      socks:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: socks
+      shoes:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: shoes
+    displacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
+            state: jumpsuit
       head:
         sizeMaps:
           32:
@@ -270,7 +300,7 @@
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
             state: outer
-      hardsuit-body-normal:
+      hardsuit:
         sizeMaps:
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
@@ -296,7 +326,7 @@
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi
             state: outer
-      hardsuit-body-normal:
+      hardsuit:
         sizeMaps:
           32:
             sprite: _Sunrise/Mobs/Species/Reptilian/displacement.rsi

--- a/Resources/Prototypes/_Sunrise/Species/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Species/humanoid_xeno.yml
@@ -27,6 +27,8 @@
     state: human
   sexes:
   - Unsexed
+  - Male
+  - Female
 
 - type: bodyType
   id: HumanoidXenoNormal

--- a/Resources/Prototypes/_Sunrise/Species/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Species/humanoid_xeno.yml
@@ -16,12 +16,12 @@
   femaleLastNames: names_xeno_last
   defaultHeight: 1.1
   defaultWidth: 1.2
-  maxHeight: 1.3
-  maxWidth: 1.3
+  maxHeight: 1.15
+  maxWidth: 1.25
   minHeight: 0.95
   minWidth: 1.05
   minHeightCm: 155
-  maxHeightCm: 350
+  maxHeightCm: 215
   buttScan:
     sprite: /Textures/_Sunrise/CopyMachine/butts_scans.rsi
     state: human

--- a/Resources/Prototypes/_Sunrise/Species/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Species/humanoid_xeno.yml
@@ -16,12 +16,12 @@
   femaleLastNames: names_xeno_last
   defaultHeight: 1.1
   defaultWidth: 1.2
-  maxHeight: 1.15
-  maxWidth: 1.25
+  maxHeight: 1.3
+  maxWidth: 1.3
   minHeight: 0.95
   minWidth: 1.05
   minHeightCm: 155
-  maxHeightCm: 215
+  maxHeightCm: 350
   buttScan:
     sprite: /Textures/_Sunrise/CopyMachine/butts_scans.rsi
     state: human


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
Вернул ксеноморфам мужской и женский пол. Теперь у них их 3, включая бесполый.
Старый пр удалился, делаю новый.
## По какой причине
Игроки не оценили то, что я сделал ксено бесполыми.

**Changelog**

:cl: seemah
- add: Ксеноморфам возвращена возможность выбрать мужской и женский пол наравне с его отсутствием.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Добавлены вариации пола: Male и Female для гуманоидных ксеноморфов.

* **Улучшения**
  * Расширены варианты отображения экипировки для женских моделей: добавлены носки, обувь, наружная одежда, броня и комбинезон.
  * Упрощены и переименованы некоторые элементы отображения экипировки для лучшей совместимости.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->