### PR TITLE
Ксеноморфы теперь действительно не дышат

### DIFF
--- a/Resources/Prototypes/_Sunrise/Body/Organs/humanoid_xeno.yml
+++ b/Resources/Prototypes/_Sunrise/Body/Organs/humanoid_xeno.yml
@@ -110,13 +110,6 @@
       - state: lung-r
   - type: Lung
   - type: Metabolizer
-    removeEmpty: true
-    solutionOnBody: false
-    solution: "Lung"
-    metabolizerTypes: [ Human ]
-    groups:
-    - id: Gas
-      rateModifier: 100.0
   - type: SolutionContainerManager
     solutions:
       organ:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
Забрал у ксеноморфов возможность усваивать газы. В принципе. Не отравиться, не вылечиться, не упороться.
## По какой причине
Ну они всё же не дышат. Лёгкие у них - рудимент, который они используют лишь для извлечения звука. 

**Changelog**

:cl: seemah
- tweak: Ксеноморфы больше не усваивают газы.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Удалена функция метаболизма газа из органов дыхания ксеноморфа, обеспечивая более сбалансированную игровую механику.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->