### PR TITLE
Фикс/Ребаланс культа

### DIFF
--- a/Content.Client/_Sunrise/BloodCult/UI/BloodSpellSelector/BloodSpellSelectorBUI.cs
+++ b/Content.Client/_Sunrise/BloodCult/UI/BloodSpellSelector/BloodSpellSelectorBUI.cs
@@ -56,7 +56,7 @@ public sealed class BloodSpellSelectorBUI : BoundUserInterface
         if (protoMan.TryIndex("BloodSpear", out EntityPrototype? bloodSpear))
         {
             var texture = sprite.GetPrototypeIcon(bloodSpear);
-            var button = _menu.AddButton($"{bloodSpear.Name} (150)", texture.Default);
+            var button = _menu.AddButton($"{bloodSpear.Name} (100)", texture.Default);
 
             button.Controller.OnPressed += _ =>
             {
@@ -70,7 +70,7 @@ public sealed class BloodSpellSelectorBUI : BoundUserInterface
         if (protoMan.TryIndex("BloodBoltBarrage", out EntityPrototype? bloodBoltBarrage))
         {
             var texture = sprite.GetPrototypeIcon(bloodBoltBarrage);
-            var button = _menu.AddButton($"{bloodBoltBarrage.Name} (300)", texture.Default);
+            var button = _menu.AddButton($"{bloodBoltBarrage.Name} (200)", texture.Default);
 
             button.Controller.OnPressed += _ =>
             {

--- a/Content.Server/_Sunrise/BloodCult/GameRule/BloodCultRuleSystem.cs
+++ b/Content.Server/_Sunrise/BloodCult/GameRule/BloodCultRuleSystem.cs
@@ -484,6 +484,9 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
         if (!_mindSystem.TryGetMind(cultist, out var mindId, out var mind))
             return false;
 
+        if (_tagSystem.HasTag(cultist, "DeconvertedCultist"))
+            return false;
+
         _roles.MindAddRole(mindId, _mindRoleCultistPrototypeId);
 
         var isHumanoid = HasComp<HumanoidAppearanceComponent>(cultist);

--- a/Content.Server/_Sunrise/BloodCult/Items/Systems/CultBloodSpellSystem.cs
+++ b/Content.Server/_Sunrise/BloodCult/Items/Systems/CultBloodSpellSystem.cs
@@ -331,8 +331,8 @@ public sealed class CultBloodSpellSystem : EntitySystem
                     ref bloodstreamComponent.BloodSolution,
                     out var bloodSolution))
             {
-                var lossBlood = bloodSolution.MaxVolume - bloodSolution.Volume;
-                if (lossBlood > 0)
+                var lossBlood = bloodstreamComponent.BloodReferenceSolution.MaxVolume - bloodSolution.Volume;
+                if (lossBlood > 50)
                 {
                     fillBlood = FixedPoint2.Min(lossBlood, availableCharges / 2);
                     _bloodstreamSystem.TryModifyBloodLevel((target, bloodstreamComponent), fillBlood);

--- a/Content.Shared/_Sunrise/BloodCult/DeconvertCultist.cs
+++ b/Content.Shared/_Sunrise/BloodCult/DeconvertCultist.cs
@@ -49,6 +49,7 @@ public sealed partial class DeconvertCultistEntityEffectSystem : EntityEffectSys
         if (entityManager.HasComponent<CultMemberComponent>(uid))
             entityManager.RemoveComponent<CultMemberComponent>(uid);
         entityManager.System<TagSystem>().RemoveTag(uid, "Cultist");
+        entityManager.System<TagSystem>().AddTag(uid, "DeconvertedCultist");
     }
 }
 

--- a/Content.Shared/_Sunrise/BloodCult/DeconvertCultist.cs
+++ b/Content.Shared/_Sunrise/BloodCult/DeconvertCultist.cs
@@ -46,8 +46,6 @@ public sealed partial class DeconvertCultistEntityEffectSystem : EntityEffectSys
 
         cultist.HolyConvertToken = null;
         entityManager.RemoveComponent<BloodCultistComponent>(uid);
-        if (entityManager.HasComponent<SharedPentagramComponent>(uid))
-            entityManager.RemoveComponent<SharedPentagramComponent>(uid);
         if (entityManager.HasComponent<CultMemberComponent>(uid))
             entityManager.RemoveComponent<CultMemberComponent>(uid);
         entityManager.System<TagSystem>().RemoveTag(uid, "Cultist");

--- a/Content.Shared/_Sunrise/BloodCult/Items/CultBloodSpellComponent.cs
+++ b/Content.Shared/_Sunrise/BloodCult/Items/CultBloodSpellComponent.cs
@@ -19,10 +19,10 @@ public sealed partial class CultBloodSpellComponent : Component
     public int BloodOrbMinCost = 50;
 
     [DataField]
-    public int BloodSpearCost = 150;
+    public int BloodSpearCost = 100;
 
     [DataField]
-    public int BloodBoltBarrageCost = 300;
+    public int BloodBoltBarrageCost = 200;
 
     [DataField]
     public EntProtoId BloodSpearSpawnId = "BloodSpear";

--- a/Resources/Prototypes/_Sunrise/BloodCult/Entities/Items/projectiles.yml
+++ b/Resources/Prototypes/_Sunrise/BloodCult/Entities/Items/projectiles.yml
@@ -39,12 +39,12 @@
   - type: BloodBolt
     damage:
       groups:
-        Brute: 20
+        Brute: 25
     healConstruct:
       groups:
-        Brute: -20
-        Burn: -20
-        Toxin: -20
+        Brute: -30
+        Burn: -30
+        Toxin: -30
     unholyVolume: 8
   - type: PointLight
     enabled: true

--- a/Resources/Prototypes/_Sunrise/BloodCult/tags.yml
+++ b/Resources/Prototypes/_Sunrise/BloodCult/tags.yml
@@ -1,2 +1,5 @@
 ﻿- type: Tag
   id: Cultist
+
+- type: Tag
+  id: DeconvertedCultist


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Цена лечения кровавым обрядом культа пофикшена и высчитывается более менее корректно.
Так же была понижена цена шквала кровавых снарядов(абсурдно высокая стоимость за один магазин снарядов со слабым лечением конструктов и слабым уроном для такой цены) и кровавого копья.
Шквалу кровавых снарядов немного увеличен урон и значительно увеличено лечение конструктов.
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Главная причина этого pr-а это баг связанный с переработкой кровеносной системы из за чего любая попытка лечения перчаткой культа пыталась восстановить в любом случае 300 крови и только потом потерянную кровь и повреждения из за чего стоимость лечения культа была абсурдно высокой.
Так же предметы кровавого обряда требуют ребаланса в связи с общими изменениями баланса в билде.
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: DerKurait
- fix: Исправлен баг подсчёта стоимости лечения кровавым обрядом культа крови.
- fix: Исправлен баг деконвертации культистов.
- tweak: Уменьшена цена на кровавое копьё и шквал кровавых снарядов культа крови.
- tweak: Увеличен урон и лечение конструктов для шквала кровавых снарядов культа крови.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Баланс**
  * Стоимость заклинаний BloodSpear снижена 150→100, BloodBoltBarrage 300→200.
  * Урон снаряда BloodBolt увеличен; усилены его восстановительные/конвертирующие эффекты.

* **Игровая механика**
  * Автоматическое пополнение крови у культистов теперь происходит только при дефиците >50, что уменьшает частые пополнения.

* **Интерфейс**
  * Обновлены подписи кнопок с новыми значениями затрат.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->