### PR TITLE
FIX: Prevent votekick crashing server when playtime data not loaded

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -520,30 +520,32 @@ namespace Content.Server.Voting.Managers
         {
             if (eligibility == VoterEligibility.All)
                 return true;
-
+        
             if (eligibility == VoterEligibility.Ghost || eligibility == VoterEligibility.GhostMinimumPlaytime)
             {
                 if (!_entityManager.TryGetComponent(player.AttachedEntity, out GhostComponent? ghostComp))
                     return false;
-
+        
                 if (eligibility == VoterEligibility.GhostMinimumPlaytime)
                 {
-                    var playtime = _playtimeManager.GetPlayTimes(player);
-                    if (!playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) || overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
+                    if (!_playtimeManager.TryGetTrackerTime(player, PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
+                        overallTime == null || 
+                        overallTime.Value < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                         return false;
-
+        
                     if ((int)_timing.RealTime.Subtract(ghostComp.TimeOfDeath).TotalSeconds < _cfg.GetCVar(CCVars.VotekickEligibleVoterDeathtime))
                         return false;
                 }
             }
-
+        
             if (eligibility == VoterEligibility.MinimumPlaytime)
             {
-                var playtime = _playtimeManager.GetPlayTimes(player);
-                if (!playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) || overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
+                if (!_playtimeManager.TryGetTrackerTime(player, PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
+                    overallTime == null || 
+                    overallTime.Value < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
             }
-
+        
             return true;
         }
 

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -515,7 +515,7 @@ namespace Content.Server.Voting.Managers
             v.OnCancelled?.Invoke(_voteHandles[v.Id]);
             DirtyCanCallVoteAll();
         }
-        
+
         public bool CheckVoterEligibility(ICommonSession player, VoterEligibility eligibility)
         {
             if (eligibility == VoterEligibility.All)

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -528,8 +528,7 @@ namespace Content.Server.Voting.Managers
 
                 if (eligibility == VoterEligibility.GhostMinimumPlaytime)
                 {
-                    if (!_playtimeManager.TryGetTrackerTimes(player, out var playtime) ||
-                        !playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) ||
+                    if (!TryGetOverallPlaytime(player, out var overallTime) ||
                         overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                         return false;
 
@@ -540,13 +539,27 @@ namespace Content.Server.Voting.Managers
 
             if (eligibility == VoterEligibility.MinimumPlaytime)
             {
-                if (!_playtimeManager.TryGetTrackerTimes(player, out var playtime) ||
-                    !playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) ||
+                if (!TryGetOverallPlaytime(player, out var overallTime) ||
                     overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
             }
 
             return true;
+        }
+
+        private bool TryGetOverallPlaytime(ICommonSession player, out TimeSpan overallTime)
+        {
+            overallTime = default;
+
+            try
+            {
+                var playTimes = _playtimeManager.GetPlayTimes(player);
+                return playTimes.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out overallTime);
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
         }
 
         public IEnumerable<IVoteHandle> ActiveVotes => _voteHandles.Values;

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -515,29 +515,29 @@ namespace Content.Server.Voting.Managers
             v.OnCancelled?.Invoke(_voteHandles[v.Id]);
             DirtyCanCallVoteAll();
         }
-
+        
         public bool CheckVoterEligibility(ICommonSession player, VoterEligibility eligibility)
         {
             if (eligibility == VoterEligibility.All)
                 return true;
-        
+
             if (eligibility == VoterEligibility.Ghost || eligibility == VoterEligibility.GhostMinimumPlaytime)
             {
                 if (!_entityManager.TryGetComponent(player.AttachedEntity, out GhostComponent? ghostComp))
                     return false;
-        
+
                 if (eligibility == VoterEligibility.GhostMinimumPlaytime)
                 {
                     if (!_playtimeManager.TryGetTrackerTime(player, PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
                         overallTime == null || 
                         overallTime.Value < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                         return false;
-        
+
                     if ((int)_timing.RealTime.Subtract(ghostComp.TimeOfDeath).TotalSeconds < _cfg.GetCVar(CCVars.VotekickEligibleVoterDeathtime))
                         return false;
                 }
             }
-        
+
             if (eligibility == VoterEligibility.MinimumPlaytime)
             {
                 if (!_playtimeManager.TryGetTrackerTime(player, PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
@@ -545,7 +545,7 @@ namespace Content.Server.Voting.Managers
                     overallTime.Value < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
             }
-        
+
             return true;
         }
 

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -545,7 +545,7 @@ namespace Content.Server.Voting.Managers
                     overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
             }
-        
+
             return true;
         }
 

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -528,8 +528,8 @@ namespace Content.Server.Voting.Managers
 
                 if (eligibility == VoterEligibility.GhostMinimumPlaytime)
                 {
-                    var playTimes = _playtimeManager.GetPlayTimes(player);
-                    if (!playTimes.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
+                    if (!_playtimeManager.TryGetTrackerTimes(player, out var playtime) ||
+                        !playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) ||
                         overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                         return false;
 
@@ -540,8 +540,8 @@ namespace Content.Server.Voting.Managers
 
             if (eligibility == VoterEligibility.MinimumPlaytime)
             {
-                var playtime = _playtimeManager.GetPlayTimes(player);
-                if (!playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) || 
+                if (!_playtimeManager.TryGetTrackerTimes(player, out var playtime) ||
+                    !playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) ||
                     overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
             }

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -528,9 +528,11 @@ namespace Content.Server.Voting.Managers
 
                 if (eligibility == VoterEligibility.GhostMinimumPlaytime)
                 {
+                    // Sunrise-Start - Safe playtime check to avoid crash when data not loaded
                     if (!TryGetOverallPlaytime(player, out var overallTime) ||
                         overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                         return false;
+                    // Sunrise-End
 
                     if ((int)_timing.RealTime.Subtract(ghostComp.TimeOfDeath).TotalSeconds < _cfg.GetCVar(CCVars.VotekickEligibleVoterDeathtime))
                         return false;
@@ -539,14 +541,21 @@ namespace Content.Server.Voting.Managers
 
             if (eligibility == VoterEligibility.MinimumPlaytime)
             {
+                // Sunrise-Start - Safe playtime check to avoid crash when data not loaded
                 if (!TryGetOverallPlaytime(player, out var overallTime) ||
                     overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
+                // Sunrise-End
             }
 
             return true;
         }
 
+        /// <summary>
+        /// Safely retrieves the overall playtime for a player.
+        /// Returns false if playtime data has not been loaded from the database yet,
+        /// instead of throwing InvalidOperationException.
+        /// </summary>
         private bool TryGetOverallPlaytime(ICommonSession player, out TimeSpan overallTime)
         {
             overallTime = default;

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -528,7 +528,7 @@ namespace Content.Server.Voting.Managers
 
                 if (eligibility == VoterEligibility.GhostMinimumPlaytime)
                 {
-                    // Sunrise-Start - Safe playtime check to avoid crash when data not loaded
+                    // Sunrise-Start
                     if (!TryGetOverallPlaytime(player, out var overallTime) ||
                         overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                         return false;
@@ -541,7 +541,7 @@ namespace Content.Server.Voting.Managers
 
             if (eligibility == VoterEligibility.MinimumPlaytime)
             {
-                // Sunrise-Start - Safe playtime check to avoid crash when data not loaded
+                // Sunrise-Start
                 if (!TryGetOverallPlaytime(player, out var overallTime) ||
                     overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -528,9 +528,9 @@ namespace Content.Server.Voting.Managers
 
                 if (eligibility == VoterEligibility.GhostMinimumPlaytime)
                 {
-                    if (!_playtimeManager.TryGetTrackerTime(player, PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
-                        overallTime == null || 
-                        overallTime.Value < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
+                    var playTimes = _playtimeManager.GetPlayTimes(player);
+                    if (!playTimes.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
+                        overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                         return false;
 
                     if ((int)_timing.RealTime.Subtract(ghostComp.TimeOfDeath).TotalSeconds < _cfg.GetCVar(CCVars.VotekickEligibleVoterDeathtime))
@@ -540,12 +540,12 @@ namespace Content.Server.Voting.Managers
 
             if (eligibility == VoterEligibility.MinimumPlaytime)
             {
-                if (!_playtimeManager.TryGetTrackerTime(player, PlayTimeTrackingShared.TrackerOverall, out var overallTime) || 
-                    overallTime == null || 
-                    overallTime.Value < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
+                var playtime = _playtimeManager.GetPlayTimes(player);
+                if (!playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) || 
+                    overallTime < TimeSpan.FromHours(_cfg.GetCVar(CCVars.VotekickEligibleVoterPlaytime)))
                     return false;
             }
-
+        
             return true;
         }
 

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -551,6 +551,7 @@ namespace Content.Server.Voting.Managers
             return true;
         }
 
+        // Sunrise added start - safely retrieve playtime without throwing InvalidOperationException
         /// <summary>
         /// Safely retrieves the overall playtime for a player.
         /// Returns false if playtime data has not been loaded from the database yet,
@@ -570,6 +571,7 @@ namespace Content.Server.Voting.Managers
                 return false;
             }
         }
+        // Sunrise added end
 
         public IEnumerable<IVoteHandle> ActiveVotes => _voteHandles.Values;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Исправление критической ошибки, приводящей к крашу сервера при инициировании голосования (votekick) если данные о времени игры игрока ещё не загружены из БД.

Добавлен вспомогательный метод `TryGetOverallPlaytime()`, который вызывает `GetPlayTimes()` через try-catch, вместо прямого вызова, выбрасывающего исключение при незагруженных данных.

## По какой причине
**Проблема:** Сервер падает с исключением `System.InvalidOperationException: Play time info is not yet loaded for this player!` если:
1. Игрок подключается к серверу
2. Немедленно инициируется голосование (votekick, restart и т.д.) с проверкой минимального времени игры
3. Данные PlayTimeTracking ещё загружаются из БД

**Решение:**
- `GetPlayTimes()` выбрасывает исключение если данные не инициализированы
- Методы `TryGetTrackerTime()`/`TryGetTrackerTimes()` существуют в `PlayTimeTrackingManager`, но не в интерфейсе `ISharedPlaytimeManager`, через который инжектится зависимость
- Добавлен `TryGetOverallPlaytime()`, который вызывает `GetPlayTimes()` в try-catch и возвращает `false` при `InvalidOperationException`
- Если время игры не загружено, игрок не проходит проверку eligibility (логичное поведение)

**Затронутые файлы:**
- `Content.Server/Voting/Managers/VoteManager.cs` - метод `CheckVoterEligibility()`, добавлен `TryGetOverallPlaytime()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Повышена надёжность проверки права голосования по минимальному времени игры: теперь при отсутствии данных о суммарном времени игрока или при ошибке их получения проверка корректно считает, что требуемый порог не подтверждён, и запрещает выдачу права голосования. Это предотвращает случайные или некорректные разрешения голосовать при проблемах со сбором времени игры.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->