### PR TITLE
Ошибочный пул

### DIFF
--- a/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_Sunrise/Maps/Pools/default.yml
@@ -8,8 +8,8 @@
 #  - SunrisePlasma
 #  - SunriseBarratry
 #  - SunriseFland
-  - SunriseMarathon
-  - SunrisePacked
+#  - SunriseMarathon
+#  - SunrisePacked
 #  - SunriseOasis
 #  - SunriseReach
 #  - SunriseRelic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->


## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->


**Сплик ещё не смотрел, потому убираю**




**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Две карты исключены из доступного пула карт Sunrise: SunriseMarathon и SunrisePacked больше не доступны для игровых сессий.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->