### PR TITLE
fix(corplaw): серый экран в картридже КЗ при отсутствии StationCorporateLawComponent

### DIFF
--- a/Content.Client/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiFragment.xaml.cs
+++ b/Content.Client/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiFragment.xaml.cs
@@ -28,17 +28,7 @@ public sealed partial class CorporateLawUiFragment : BoxContainer
 
         if (!state.Connected)
         {
-            var noConnectionLabel = new RichTextLabel
-            {
-                HorizontalAlignment = Control.HAlignment.Center,
-                VerticalAlignment = Control.VAlignment.Center,
-                HorizontalExpand = true,
-                VerticalExpand = true,
-                Margin = new Thickness(16)
-            };
-            noConnectionLabel.SetMessage(FormattedMessage.FromMarkupOrThrow(
-                $"[color={HeaderColor.ToHex()}][bold]{Loc.GetString("corplaw-no-connection")}[/bold][/color]"));
-            MainContainer.AddChild(noConnectionLabel);
+            MainContainer.AddChild(BuildNoConnectionPanel());
             return;
         }
 
@@ -172,5 +162,66 @@ public sealed partial class CorporateLawUiFragment : BoxContainer
 
             sectionHeading.OnPressed += _ => sectionCollapsible.BodyVisible = !sectionCollapsible.BodyVisible;
         }
+    }
+
+    private static Control BuildNoConnectionPanel()
+    {
+        var accent = Color.FromHex("#ff4d4d");
+        var muted = Color.FromHex("#8d9bb2");
+
+        var panelStyle = new StyleBoxFlat
+        {
+            BackgroundColor = accent.WithAlpha(0.08f),
+            BorderColor = accent.WithAlpha(0.5f),
+            BorderThickness = new Thickness(2),
+            ContentMarginLeftOverride = 24,
+            ContentMarginRightOverride = 24,
+            ContentMarginTopOverride = 20,
+            ContentMarginBottomOverride = 20
+        };
+
+        var panel = new PanelContainer
+        {
+            PanelOverride = panelStyle,
+            HorizontalAlignment = Control.HAlignment.Center,
+            VerticalAlignment = Control.VAlignment.Center,
+            Margin = new Thickness(16)
+        };
+
+        var content = new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalAlignment = Control.HAlignment.Center,
+            SeparationOverride = 8
+        };
+
+        var heading = new RichTextLabel
+        {
+            HorizontalAlignment = Control.HAlignment.Center
+        };
+        heading.SetMessage(FormattedMessage.FromMarkupOrThrow(
+            $"[color={accent.ToHex()}][font size=18][bold]⚠  {Loc.GetString("corplaw-no-connection")}[/bold][/font][/color]"));
+        content.AddChild(heading);
+
+        var divider = new PanelContainer
+        {
+            PanelOverride = new StyleBoxFlat { BackgroundColor = accent.WithAlpha(0.35f) },
+            MinHeight = 1,
+            HorizontalExpand = true,
+            Margin = new Thickness(0, 2, 0, 2)
+        };
+        content.AddChild(divider);
+
+        var desc = new RichTextLabel
+        {
+            HorizontalAlignment = Control.HAlignment.Center,
+            MaxWidth = 360
+        };
+        desc.SetMessage(FormattedMessage.FromMarkupOrThrow(
+            $"[color={muted.ToHex()}]{Loc.GetString("corplaw-no-connection-desc")}[/color]"));
+        content.AddChild(desc);
+
+        panel.AddChild(content);
+        return panel;
     }
 }

--- a/Content.Client/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiFragment.xaml.cs
+++ b/Content.Client/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiFragment.xaml.cs
@@ -15,6 +15,25 @@ public sealed partial class CorporateLawUiFragment : BoxContainer
     private static readonly Color BackgroundColor = Color.FromHex("#1a2332");
     private static readonly Color BackgroundColorDark = Color.FromHex("#141a26");
 
+    private static readonly Color NoConnectionAccent = Color.FromHex("#ff4d4d");
+    private static readonly Color NoConnectionMuted = Color.FromHex("#8d9bb2");
+
+    private static readonly StyleBoxFlat NoConnectionPanelStyle = new()
+    {
+        BackgroundColor = NoConnectionAccent.WithAlpha(0.08f),
+        BorderColor = NoConnectionAccent.WithAlpha(0.5f),
+        BorderThickness = new Thickness(2),
+        ContentMarginLeftOverride = 24,
+        ContentMarginRightOverride = 24,
+        ContentMarginTopOverride = 20,
+        ContentMarginBottomOverride = 20
+    };
+
+    private static readonly StyleBoxFlat NoConnectionDividerStyle = new()
+    {
+        BackgroundColor = NoConnectionAccent.WithAlpha(0.35f)
+    };
+
     public CorporateLawUiFragment()
     {
         RobustXamlLoader.Load(this);
@@ -166,23 +185,9 @@ public sealed partial class CorporateLawUiFragment : BoxContainer
 
     private static Control BuildNoConnectionPanel()
     {
-        var accent = Color.FromHex("#ff4d4d");
-        var muted = Color.FromHex("#8d9bb2");
-
-        var panelStyle = new StyleBoxFlat
-        {
-            BackgroundColor = accent.WithAlpha(0.08f),
-            BorderColor = accent.WithAlpha(0.5f),
-            BorderThickness = new Thickness(2),
-            ContentMarginLeftOverride = 24,
-            ContentMarginRightOverride = 24,
-            ContentMarginTopOverride = 20,
-            ContentMarginBottomOverride = 20
-        };
-
         var panel = new PanelContainer
         {
-            PanelOverride = panelStyle,
+            PanelOverride = NoConnectionPanelStyle,
             HorizontalAlignment = Control.HAlignment.Center,
             VerticalAlignment = Control.VAlignment.Center,
             Margin = new Thickness(16)
@@ -200,12 +205,12 @@ public sealed partial class CorporateLawUiFragment : BoxContainer
             HorizontalAlignment = Control.HAlignment.Center
         };
         heading.SetMessage(FormattedMessage.FromMarkupOrThrow(
-            $"[color={accent.ToHex()}][font size=18][bold]⚠  {Loc.GetString("corplaw-no-connection")}[/bold][/font][/color]"));
+            $"[color={NoConnectionAccent.ToHex()}][font size=18][bold]⚠  {Loc.GetString("corplaw-no-connection")}[/bold][/font][/color]"));
         content.AddChild(heading);
 
         var divider = new PanelContainer
         {
-            PanelOverride = new StyleBoxFlat { BackgroundColor = accent.WithAlpha(0.35f) },
+            PanelOverride = NoConnectionDividerStyle,
             MinHeight = 1,
             HorizontalExpand = true,
             Margin = new Thickness(0, 2, 0, 2)
@@ -218,7 +223,7 @@ public sealed partial class CorporateLawUiFragment : BoxContainer
             MaxWidth = 360
         };
         desc.SetMessage(FormattedMessage.FromMarkupOrThrow(
-            $"[color={muted.ToHex()}]{Loc.GetString("corplaw-no-connection-desc")}[/color]"));
+            $"[color={NoConnectionMuted.ToHex()}]{Loc.GetString("corplaw-no-connection-desc")}[/color]"));
         content.AddChild(desc);
 
         panel.AddChild(content);

--- a/Content.Client/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiFragment.xaml.cs
+++ b/Content.Client/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiFragment.xaml.cs
@@ -26,6 +26,22 @@ public sealed partial class CorporateLawUiFragment : BoxContainer
         MainContainer.DisposeAllChildren();
         MainContainer.SeparationOverride = 8;
 
+        if (!state.Connected)
+        {
+            var noConnectionLabel = new RichTextLabel
+            {
+                HorizontalAlignment = Control.HAlignment.Center,
+                VerticalAlignment = Control.VAlignment.Center,
+                HorizontalExpand = true,
+                VerticalExpand = true,
+                Margin = new Thickness(16)
+            };
+            noConnectionLabel.SetMessage(FormattedMessage.FromMarkupOrThrow(
+                $"[color={HeaderColor.ToHex()}][bold]{Loc.GetString("corplaw-no-connection")}[/bold][/color]"));
+            MainContainer.AddChild(noConnectionLabel);
+            return;
+        }
+
         foreach (var section in state.Sections)
         {
             var sectionColor = section.Color ?? HeaderColor;

--- a/Content.Server/_Sunrise/CartridgeLoader/Cartridges/CorporateLawCartridgeSystem.cs
+++ b/Content.Server/_Sunrise/CartridgeLoader/Cartridges/CorporateLawCartridgeSystem.cs
@@ -24,15 +24,21 @@ public sealed class CorporateLawCartridgeSystem : EntitySystem
 
     private void OnUiReady(Entity<CorporateLawCartridgeComponent> ent, ref CartridgeUiReadyEvent args)
     {
-        _stationLaw.GetEffectiveLawset(args.Loader, out var provisions, out var articles, out var circumstances, out _);
+        var lawsetComp = _stationLaw.GetStationLawset(args.Loader);
+        if (lawsetComp == null)
+        {
+            _cartridgeLoader.UpdateCartridgeUiState(args.Loader, new CorporateLawUiState(new List<LawSection>(), connected: false));
+            return;
+        }
 
+        var lawset = lawsetComp.Value.Comp;
         var sections = new List<LawSection>();
 
         // 1. General Provisions
-        if (provisions.Count > 0)
+        if (lawset.Provisions.Count > 0)
         {
             var provisionEntries = new List<LawEntry>();
-            foreach (var entryId in provisions)
+            foreach (var entryId in lawset.Provisions)
             {
                 if (!_prototype.TryIndex(entryId, out var entry))
                     continue;
@@ -44,7 +50,7 @@ public sealed class CorporateLawCartridgeSystem : EntitySystem
         }
 
         // 2. Legal Articles (Categorized)
-        foreach (var sectionId in articles)
+        foreach (var sectionId in lawset.Articles)
         {
             if (!_prototype.TryIndex(sectionId, out var section))
                 continue;
@@ -62,12 +68,12 @@ public sealed class CorporateLawCartridgeSystem : EntitySystem
         }
 
         // 3. Modifiers (Circumstances)
-        if (circumstances.Count > 0)
+        if (lawset.Circumstances.Count > 0)
         {
             var mitEntries = new List<LawEntry>();
             var aggEntries = new List<LawEntry>();
 
-            foreach (var entryId in circumstances)
+            foreach (var entryId in lawset.Circumstances)
             {
                 if (!_prototype.TryIndex(entryId, out var entry) || entry.Category == LawCategory.Provision)
                     continue;

--- a/Content.Server/_Sunrise/CartridgeLoader/Cartridges/CorporateLawCartridgeSystem.cs
+++ b/Content.Server/_Sunrise/CartridgeLoader/Cartridges/CorporateLawCartridgeSystem.cs
@@ -24,19 +24,15 @@ public sealed class CorporateLawCartridgeSystem : EntitySystem
 
     private void OnUiReady(Entity<CorporateLawCartridgeComponent> ent, ref CartridgeUiReadyEvent args)
     {
-        var lawsetComp = _stationLaw.GetStationLawset(args.Loader);
-        if (lawsetComp == null)
-            return;
-
-        var lawset = lawsetComp.Value.Comp;
+        _stationLaw.GetEffectiveLawset(args.Loader, out var provisions, out var articles, out var circumstances, out _);
 
         var sections = new List<LawSection>();
 
         // 1. General Provisions
-        if (lawset.Provisions.Count > 0)
+        if (provisions.Count > 0)
         {
             var provisionEntries = new List<LawEntry>();
-            foreach (var entryId in lawset.Provisions)
+            foreach (var entryId in provisions)
             {
                 if (!_prototype.TryIndex(entryId, out var entry))
                     continue;
@@ -48,7 +44,7 @@ public sealed class CorporateLawCartridgeSystem : EntitySystem
         }
 
         // 2. Legal Articles (Categorized)
-        foreach (var sectionId in lawset.Articles)
+        foreach (var sectionId in articles)
         {
             if (!_prototype.TryIndex(sectionId, out var section))
                 continue;
@@ -66,12 +62,12 @@ public sealed class CorporateLawCartridgeSystem : EntitySystem
         }
 
         // 3. Modifiers (Circumstances)
-        if (lawset.Circumstances.Count > 0)
+        if (circumstances.Count > 0)
         {
             var mitEntries = new List<LawEntry>();
             var aggEntries = new List<LawEntry>();
 
-            foreach (var entryId in lawset.Circumstances)
+            foreach (var entryId in circumstances)
             {
                 if (!_prototype.TryIndex(entryId, out var entry) || entry.Category == LawCategory.Provision)
                     continue;

--- a/Content.Shared/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiState.cs
+++ b/Content.Shared/_Sunrise/CartridgeLoader/Cartridges/CorporateLawUiState.cs
@@ -7,10 +7,12 @@ namespace Content.Shared._Sunrise.CartridgeLoader.Cartridges;
 public sealed class CorporateLawUiState : BoundUserInterfaceState
 {
     public readonly List<LawSection> Sections;
+    public readonly bool Connected;
 
-    public CorporateLawUiState(List<LawSection> sections)
+    public CorporateLawUiState(List<LawSection> sections, bool connected = true)
     {
         Sections = sections;
+        Connected = connected;
     }
 }
 

--- a/Resources/Locale/ru-RU/_strings/_sunrise/corplaw.ftl
+++ b/Resources/Locale/ru-RU/_strings/_sunrise/corplaw.ftl
@@ -2,6 +2,9 @@
 
 corplaw-program-name = Корпоративный Закон
 
+# Shown when the PDA is not on a station with StationCorporateLawComponent
+corplaw-no-connection = Нет соединения
+
 # Sections
 corplaw-section-general = Общие положения
 corplaw-section-1xx = 1xx: Мелкие правонарушения


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Кратное описание
`CorporateLawCartridgeSystem.OnUiReady` теперь использует `GetEffectiveLawset`, у которого встроен fallback на прототип из CVar `sunrise.corporate_law_set`. Раньше использовался `GetStationLawset`, который возвращал `null` и система тихо выходила, не отправляя состояние клиенту, а итог: пустой (серый) экран КЗ в КПК.

## По какой причине
В PR #4281 чтение CVar было заменено на `GetStationLawset(args.Loader)`:
```csharp
var lawsetComp = _stationLaw.GetStationLawset(args.Loader);
if (lawsetComp == null)
    return;
```
Эта функция возвращает `null`, если:
1. `GetOwningStation(PDA)` не нашёл станцию (например, КПК вне станции, в шаттле посетителей, на тестовой карте и т.п.);
2. На станции ещё/уже нет `StationCorporateLawComponent` (не сработал `StationInitializedEvent`, или карта грузилась до инициализации системы).

В любом из этих случаев сервер делал `return` и не вызывал `UpdateCartridgeUiState`. На клиенте `CorporateLawUiFragment` создавался в `Setup()`, но `UpdateState` никогда не вызывался, поэтому `MainContainer` оставался пустым и визуально это выглядит как серый экран без заголовков и статей.

В этом же PR #4281 специально для подобных случаев был добавлен `GetEffectiveLawset`, который при отсутствии компонента на станции падает обратно на прототип из CVar. Его уже корректно использует `SharedSunriseCriminalRecordsSystem` и `PrisonerManagementConsoleSystem`, но в картридже КЗ его (видимо) забыли применить.

Фикс заменяет `GetStationLawset(...)` на `GetEffectiveLawset(args.Loader, out var provisions, out var articles, out var circumstances, out _)` и использует эти списки вместо `lawset.Provisions`, `lawset.Articles`, `lawset.Circumstances`. Теперь UI картриджа заполняется данными всегда, когда CVar `sunrise.corporate_law_set` указывает на валидный `corporateLawset` прототип (по умолчанию это `StandardCorporateLaw`).

## Медиа(Видео/Скриншоты)
Изменения только в серверной C#-логике, визуальных изменений в UI нет, а только перестаёт быть пустым.
<img width="774" height="545" alt="image" src="https://github.com/user-attachments/assets/8cc264cf-54d2-4d56-9685-481aef2689d1" />
<img width="774" height="545" alt="image" src="https://github.com/user-attachments/assets/85f100ca-ad9e-4d24-a9a5-2b49d1691cf3" />
<img width="774" height="545" alt="image" src="https://github.com/user-attachments/assets/4233283e-2a55-4297-84dc-f18b48b33569" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Улучшена система обработки и отображения правовых данных в системе корпоративного права. Оптимизирован механизм получения и организации информации о положениях, статьях и обстоятельствах при загрузке интерфейса.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->