### PR TITLE
Улучшение консолей заказов

### DIFF
--- a/Content.Client/Cargo/UI/CargoConsoleMenu.xaml.cs
+++ b/Content.Client/Cargo/UI/CargoConsoleMenu.xaml.cs
@@ -227,6 +227,7 @@ namespace Content.Client.Cargo.UI
                             "cargo-console-menu-populate-orders-cargo-order-row-product-name-text",
                             ("productName", productName),
                             ("orderAmount", order.OrderQuantity),
+                            ("cost", order.Price * order.OrderQuantity), //Sunrise-Add
                             ("orderRequester", order.Requester),
                             ("accountColor", account.Color),
                             ("account", Loc.GetString(account.Code)))
@@ -234,7 +235,10 @@ namespace Content.Client.Cargo.UI
                     Description =
                     {
                         Text = Loc.GetString("cargo-console-menu-order-reason-description",
-                                                        ("reason", order.Reason))
+                                                        ("orderRequester", order.Requester), //Sunrise-Edit
+                                                        ("account", Loc.GetString(account.Code)), //Sunrise-Edit
+                                                        ("accountColor", account.Color), //Sunrise-Edit
+                                                        ("reason", order.Reason)) //Sunrise-Edit
                     }
                 };
                 row.Cancel.OnPressed += (args) => { OnOrderCanceled?.Invoke(args); };

--- a/Content.Client/Cargo/UI/CargoConsoleMenu.xaml.cs
+++ b/Content.Client/Cargo/UI/CargoConsoleMenu.xaml.cs
@@ -235,9 +235,7 @@ namespace Content.Client.Cargo.UI
                     Description =
                     {
                         Text = Loc.GetString("cargo-console-menu-order-reason-description",
-                                                        ("orderRequester", order.Requester), //Sunrise-Edit
-                                                        ("account", Loc.GetString(account.Code)), //Sunrise-Edit
-                                                        ("accountColor", account.Color), //Sunrise-Edit
+                                                        ("orderRequester", order.Requester), //Sunrise-Add
                                                         ("reason", order.Reason)) //Sunrise-Edit
                     }
                 };

--- a/Resources/Locale/en-US/_strings/cargo/cargo-console-component.ftl
+++ b/Resources/Locale/en-US/_strings/cargo/cargo-console-component.ftl
@@ -16,9 +16,9 @@ cargo-console-menu-categories-label = Categories:{" "}
 cargo-console-menu-search-bar-placeholder = Search
 cargo-console-menu-requests-label = Requests
 cargo-console-menu-orders-label = Orders
-cargo-console-menu-order-reason-description = Reasons: {$reason}
+cargo-cocargo-console-menu-order-reason-description = Ordered by { $orderRequester }, reason: { $reason }
 cargo-console-menu-populate-categories-all-text = All
-cargo-console-menu-populate-orders-cargo-order-row-product-name-text = {$productName} (x{$orderAmount}) by {$orderRequester} from [color={$accountColor}]{$account}[/color]
+cargo-console-menu-populate-orders-cargo-order-row-product-name-text = Order from [bold][color={ $accountColor }]{ $account }[/color][/bold]: { $productName } x{ $orderAmount }. Cost: { $cost }$
 cargo-console-menu-cargo-order-row-approve-button = Approve
 cargo-console-menu-cargo-order-row-cancel-button = Cancel
 cargo-console-menu-tab-title-orders = Orders

--- a/Resources/Locale/en-US/_strings/cargo/cargo-console-component.ftl
+++ b/Resources/Locale/en-US/_strings/cargo/cargo-console-component.ftl
@@ -16,7 +16,7 @@ cargo-console-menu-categories-label = Categories:{" "}
 cargo-console-menu-search-bar-placeholder = Search
 cargo-console-menu-requests-label = Requests
 cargo-console-menu-orders-label = Orders
-cargo-cocargo-console-menu-order-reason-description = Ordered by { $orderRequester }, reason: { $reason }
+cargo-console-menu-order-reason-description = Ordered by { $orderRequester }, reason: { $reason }
 cargo-console-menu-populate-categories-all-text = All
 cargo-console-menu-populate-orders-cargo-order-row-product-name-text = Order from [bold][color={ $accountColor }]{ $account }[/color][/bold]: { $productName } x{ $orderAmount }. Cost: { $cost }$
 cargo-console-menu-cargo-order-row-approve-button = Approve

--- a/Resources/Locale/ru-RU/_strings/cargo/cargo-console-component.ftl
+++ b/Resources/Locale/ru-RU/_strings/cargo/cargo-console-component.ftl
@@ -16,9 +16,9 @@ cargo-console-menu-categories-label = Категории:{ " " }
 cargo-console-menu-search-bar-placeholder = Поиск
 cargo-console-menu-requests-label = Запросы
 cargo-console-menu-orders-label = Заказы
-cargo-console-menu-order-reason-description = Причина: { $reason }
+cargo-console-menu-order-reason-description = Заказал {$orderRequester}, по причине: { $reason }
 cargo-console-menu-populate-categories-all-text = Все
-cargo-console-menu-populate-orders-cargo-order-row-product-name-text = { $productName } (x{ $orderAmount }) от { $orderRequester }
+cargo-console-menu-populate-orders-cargo-order-row-product-name-text = Заказ от [bold][color={ $accountColor }]{ $account }[/color][/bold]: { $productName } x{ $orderAmount }. Цена: { $cost }$
 cargo-console-menu-cargo-order-row-approve-button = Одобрить
 cargo-console-menu-cargo-order-row-cancel-button = Отменить
 # Orders


### PR DESCRIPTION

## Краткое описание | Short description
Новые данные для отображения в консолях заказов грузов. Теперь Карго видит отдел-заказчик и окончательную стоимость заказа. Имя заказчика снесено на вторую строчку вместо первой.

## Ссылка на багрепорт/Предложение | Related Issue/Bug Report
[Issue #4024](https://github.com/space-sunrise/sunrise-station/issues/4024)

## Медиа (Видео/Скриншоты) | Media (Video/Screenshots)
<img width="668" height="646" alt="Снимок экрана — 2026-05-03 в 13 01 17" src="https://github.com/user-attachments/assets/ba238490-f409-4e68-a0a4-834046b17f55" />
<img width="567" height="554" alt="Снимок экрана — 2026-05-03 в 13 10 27" src="https://github.com/user-attachments/assets/92b2f7b4-12be-4cb8-9d86-fa71df1c6c37" />
<img width="546" height="552" alt="Снимок экрана — 2026-05-03 в 13 17 54" src="https://github.com/user-attachments/assets/0eca3b99-24c0-422b-a850-2152d261f0ae" />


**Changelog**
add: Добавлено отображение окончательной стоимости заказа в консоли заказов.
add: Добавлена метка отдела-заказчика в консолях заказов.
tweak: Изменено отображения данных заказов в консоли (Имя заказчика перенесено на вторую строчку, когда раньше находилось на первой)


:cl: Coconut_Law
- add: Отображение метки отдела-заказчика в консоли заказов
- add: Отображение окончательной стоимости заказа в консоли заказов


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **New Features**
  * Информация о стоимости заказа теперь отображается в списке товаров.
  * Описание причины заказа дополнено данными о заказчике и аккаунте.
  * Улучшено отображение деталей заказа с форматированием информации об аккаунте.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->