### PR TITLE
ПТ | Добавил бодикамеру в лодаут "С собой" тюремной охране за 0 часов + фикс дубликата

### DIFF
--- a/Resources/Prototypes/_Sunrise/Loadouts/Shared/Groups/loadout_groups.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/Shared/Groups/loadout_groups.yml
@@ -1566,10 +1566,10 @@
 - type: loadoutGroup
   id: PlanetPrisonSecurityLoot
   name: loadout-group-prison-security-loot
-  minLimit: 0
+  minLimit: 1
   maxLimit: 1
   loadouts:
-  - PlanetPrisonSecurityMasterHandheldCamera
+  - PlanetPrisonSecurityHandheldCamera
   - PlanetPrisonSecurityMasterHandheldCamera
 
 # Planet Prison - Inspector

--- a/Resources/Prototypes/_Sunrise/Loadouts/Shared/Loadouts/Miscellaneous/planet_prison_security.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/Shared/Loadouts/Miscellaneous/planet_prison_security.yml
@@ -1,12 +1,19 @@
 # Neck
 
 - type: loadout
+  id: PlanetPrisonSecurityHandheldCamera
+  groupBy: "bodycam"
+  equipment:
+    neck: HandheldCamera
+
+- type: loadout
   id: PlanetPrisonSecurityMasterHandheldCamera
+  groupBy: "bodycam"
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: PlanetPrisonSecurity
       time: 108000 # 30 hrs
-  inhand:
-  - MasterHandheldCamera
+  equipment:
+    neck: MasterHandheldCamera


### PR DESCRIPTION
## Краткое описание | Short description
1. Добавлена HandheldCamera в лодауте "С собой" тюремной охране за 0 часов
2. Фикс дубликата MasterHandheldCamera в лодауте "С собой"
3. Изменил лимит лодаута с 0 на 1 (ибо бодикамера за 0 часов)

**Changelog**
:cl: ПТ | KAVALDi
- add: Добавлена нагрудная камера за 0 часов тюремной охране в лодаут "С собой"
- fix: Исправлен дубликат усовершенствованной бодикамеры в лодауте тюремной охране "С собой"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Добавлена стандартная портативная видеокамера для персонала

* **Изменения**
  * Видеокамеры теперь экипируются на шею вместо удержания в руке, обеспечивая более удобное использование
  * Обновлены требования доступа к расширенной видеокамере

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/space-sunrise/sunrise-station/pull/4417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->