### PR TITLE
Фикс требуемого времени для открытия ролей ксеноборгов и центрального ИИ, при игре на боргах отделов

### DIFF
--- a/Resources/Prototypes/Roles/Antags/xenoborgs.yml
+++ b/Resources/Prototypes/Roles/Antags/xenoborgs.yml
@@ -9,7 +9,6 @@
   # SunriseEdit Start
   #- !type:RoleTimeRequirement
   #  role: JobBorg
-  #  time: 18000  # 5 hrs
   - !type:DepartmentTimeRequirement
     department: Silicon
     time: 18000 # 5 hrs
@@ -27,7 +26,6 @@
   # SunriseEdit Start
   #- !type:RoleTimeRequirement
   #  role: JobBorg
-  #  time: 18000  # 5 hrs
   - !type:DepartmentTimeRequirement
     department: Silicon
     time: 18000 # 5 hrs

--- a/Resources/Prototypes/Roles/Antags/xenoborgs.yml
+++ b/Resources/Prototypes/Roles/Antags/xenoborgs.yml
@@ -6,9 +6,14 @@
   playTimeTracker: MothershipCore # Sunrise
   objective: roles-antag-mothership-core-objective
   requirements:
-  - !type:RoleTimeRequirement
-    role: JobBorg
-    time: 18000  # 5 hrs
+  # SunriseEdit Start
+  #- !type:RoleTimeRequirement
+  #  role: JobBorg
+  #  time: 18000  # 5 hrs
+  - !type:DepartmentTimeRequirement
+    department: Silicon
+    time: 18000 # 5 hrs
+  # SunriseEdit End
   guides: [ Xenoborgs ]
 
 - type: antag
@@ -19,7 +24,12 @@
   playTimeTracker: Xenoborg # Sunrise
   objective: roles-antag-xenoborg-objective
   requirements:
-  - !type:RoleTimeRequirement
-    role: JobBorg
-    time: 18000  # 5 hrs
+  # SunriseEdit Start
+  #- !type:RoleTimeRequirement
+  #  role: JobBorg
+  #  time: 18000  # 5 hrs
+  - !type:DepartmentTimeRequirement
+    department: Silicon
+    time: 18000 # 5 hrs
+  # SunriseEdit End
   guides: [ Xenoborgs ]

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -9,7 +9,6 @@
   # SunriseEdit Start
   #- !type:RoleTimeRequirement
   #  role: JobBorg
-  #  time: 5h
   - !type:DepartmentTimeRequirement
     department: Silicon
     time: 5h

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -6,9 +6,14 @@
   description: job-description-station-ai
   playTimeTracker: JobStationAi
   requirements:
-  - !type:RoleTimeRequirement
-    role: JobBorg
+  # SunriseEdit Start
+  #- !type:RoleTimeRequirement
+  #  role: JobBorg
+  #  time: 5h
+  - !type:DepartmentTimeRequirement
+    department: Silicon
     time: 5h
+  # SunriseEdit End
   weight: 10
   canBeAntag: false
   icon: JobIconStationAi


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
<!--
[RU] Что вы предлагаете изменить с помощью своего PR?
[EN] What does this PR propose to change?
-->
**Фикс требуемого времени для открытия ролей ксеноборгов и центрального ИИ, при игре на боргах отделов**

## Ссылка на багрепорт/Предложение | Related Issue/Bug Report
<!--
[RU] Ссылки на Дискуссии и Баг-репорты указывать здесь.
[EN] Provide links to Discussions or Bug Reports here.
-->

## Медиа (Видео/Скриншоты) | Media (Video/Screenshots)
<!--
[RU] Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
[EN] If your PR contains in-game changes, you must provide screenshots/video of the changes.
-->

<!--
## TODO

[RU] Не закончили? Добавьте список того, что требуется для завершения PR'а.
[EN] Not finished yet? Add a list of things that need to be done to complete this PR.

- [ ] Task 1
- [ ] Task 2
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Изменения в выпуске

* **Изменения игровых механик**
  * Обновлены требования опыта для антагонистских ролей и роли станционного ИИ. Теперь они требуют опыта в отделе «Кремний» вместо специализированного опыта в конкретной роли. Время требуемого опыта остаётся неизменным.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->