### PR TITLE
HOTFIX: стрельба по македонски

### DIFF
--- a/Content.Shared/_Sunrise/Weapons/DualWield/SharedDualWieldSystem.cs
+++ b/Content.Shared/_Sunrise/Weapons/DualWield/SharedDualWieldSystem.cs
@@ -137,6 +137,9 @@ public sealed class SharedDualWieldSystem : EntitySystem
         if (!TryComp<DualWieldComponent>(wielder, out var dualWield))
             return;
 
+        if (dualWield.LifeStage > ComponentLifeStage.Running)
+            return;
+
         if (dualWield.LeftGun != ent && dualWield.RightGun != ent)
             return;
 


### PR DESCRIPTION
Fixes #4460
:cl: Fooksy2304
- fix: исправлена ошибка из-за которой стрельба по-македонски не возвращала оригинальную скорость стрельбы оружия


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Bug Fixes**
  * Исправлено поведение модификаторов оружия при использовании двойного оружия. Система теперь корректно прекращает применение штрафов, когда оружие завершает цикл жизни, что предотвращает неправильное изменение характеристик вроде увеличения угла, скорости стрельбы и отдачи.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->