### PR TITLE
HOTFIX: ДАТЧИКИ

### DIFF
--- a/Content.Client/_Sunrise/Medical/CrewMonitoring/SunriseCrewMonitoringWindow.xaml.cs
+++ b/Content.Client/_Sunrise/Medical/CrewMonitoring/SunriseCrewMonitoringWindow.xaml.cs
@@ -220,14 +220,10 @@ public sealed partial class SunriseCrewMonitoringWindow : FancyWindow
 
     private SpriteSpecifier.Rsi GetIconSpecifier(SuitSensorStatus sensor)
     {
-        // Binary sensors (without health data) should display only alive/dead states
-        // instead of falling through to Unknown state via HealthStateHelper
-        if (sensor.DamagePercentage == null)
-            return new SpriteSpecifier.Rsi(new ResPath(HumanCrewMonitoringRsi), sensor.IsAlive ? "alive" : "dead");
-
         var healthState = HealthStateHelper.GetHealthState(sensor.DamagePercentage, sensor.IsAlive);
         string rsiState = healthState switch
         {
+            CrewMonitoringHealthState.Alive => "alive",
             CrewMonitoringHealthState.Healthy => "health0",
             CrewMonitoringHealthState.Good => "health1",
             CrewMonitoringHealthState.NotGreat => "health2",

--- a/Content.Client/_Sunrise/Medical/CrewMonitoring/SunriseCrewMonitoringWindow.xaml.cs
+++ b/Content.Client/_Sunrise/Medical/CrewMonitoring/SunriseCrewMonitoringWindow.xaml.cs
@@ -220,6 +220,8 @@ public sealed partial class SunriseCrewMonitoringWindow : FancyWindow
 
     private SpriteSpecifier.Rsi GetIconSpecifier(SuitSensorStatus sensor)
     {
+        // Binary sensors (without health data) should display only alive/dead states
+        // instead of falling through to Unknown state via HealthStateHelper
         if (sensor.DamagePercentage == null)
             return new SpriteSpecifier.Rsi(new ResPath(HumanCrewMonitoringRsi), sensor.IsAlive ? "alive" : "dead");
 

--- a/Content.Client/_Sunrise/Medical/CrewMonitoring/SunriseCrewMonitoringWindow.xaml.cs
+++ b/Content.Client/_Sunrise/Medical/CrewMonitoring/SunriseCrewMonitoringWindow.xaml.cs
@@ -220,6 +220,9 @@ public sealed partial class SunriseCrewMonitoringWindow : FancyWindow
 
     private SpriteSpecifier.Rsi GetIconSpecifier(SuitSensorStatus sensor)
     {
+        if (sensor.DamagePercentage == null)
+            return new SpriteSpecifier.Rsi(new ResPath(HumanCrewMonitoringRsi), sensor.IsAlive ? "alive" : "dead");
+
         var healthState = HealthStateHelper.GetHealthState(sensor.DamagePercentage, sensor.IsAlive);
         string rsiState = healthState switch
         {

--- a/Content.Shared/_Sunrise/Medical/CrewMonitoring/HealthState.cs
+++ b/Content.Shared/_Sunrise/Medical/CrewMonitoring/HealthState.cs
@@ -15,7 +15,8 @@ public enum CrewMonitoringHealthState
     Bad,
     Terrible,
     Critical,
-    Dead
+    Dead,
+    Alive
 }
 
 public static class HealthStateHelper
@@ -43,7 +44,7 @@ public static class HealthStateHelper
             return CrewMonitoringHealthState.Dead;
 
         if (damagePercentage == null)
-            return CrewMonitoringHealthState.Healthy;
+            return CrewMonitoringHealthState.Alive;
 
         var damageRatio = damagePercentage.Value;
 

--- a/Content.Shared/_Sunrise/Medical/CrewMonitoring/HealthState.cs
+++ b/Content.Shared/_Sunrise/Medical/CrewMonitoring/HealthState.cs
@@ -43,7 +43,7 @@ public static class HealthStateHelper
             return CrewMonitoringHealthState.Dead;
 
         if (damagePercentage == null)
-            return CrewMonitoringHealthState.Unknown;
+            return CrewMonitoringHealthState.Healthy;
 
         var damageRatio = damagePercentage.Value;
 

--- a/Content.Shared/_Sunrise/Medical/CrewMonitoring/HealthState.cs
+++ b/Content.Shared/_Sunrise/Medical/CrewMonitoring/HealthState.cs
@@ -43,7 +43,7 @@ public static class HealthStateHelper
             return CrewMonitoringHealthState.Dead;
 
         if (damagePercentage == null)
-            return CrewMonitoringHealthState.Healthy;
+            return CrewMonitoringHealthState.Unknown;
 
         var damageRatio = damagePercentage.Value;
 


### PR DESCRIPTION


:cl: Fooksy2304
- fix: исправлена ошибка с неправильным отображением бинарных датчиков, теперь состояния жив/мёртв отображаются корректно.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Исправлена обработка отсутствующих данных о повреждениях: при недоступных значениях состояние экипажа теперь считается «здоров» (Alive) вместо «неизвестно», обеспечивая однозначное отображение.
  * Статус отображения (иконка/параметр состояния) теперь корректно показывает «alive» для здорового состояния экипажа.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->