### PR TITLE
Убрал резкое окончания раунда при мажорной победе или поражении некоторых антагонистов

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -251,11 +251,13 @@ public sealed class NukeOpsTest
                     Is.False,
                     $"The round ended, but {nukies.Length - i - 1} nukies are still alive!");
             }
-            // Delete the last nukie and make sure the round ends.
+            // Delete the last nukie and make sure the game rule ends (but the round does not)
             entMan.DeleteEntity(nukies[^1]);
 
-            Assert.That(roundEndSys.IsRoundEndRequested,
-                "All nukies were deleted, but the round didn't end!");
+            // Sunrise edit start - death of nukies ends the rule, not the round
+            Assert.That(ticker.IsGameRuleActive(rule.Uid), Is.False, "Game rule should have ended");
+            Assert.That(roundEndSys.IsRoundEndRequested, Is.False, "Round should not have ended");
+            // Sunrise edit end
         });
 
         ticker.SetGamePreset((GamePresetPrototype?) null);

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -429,7 +429,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         }
     }
 
-    private void SetWinType(Entity<NukeopsRuleComponent> ent, WinType type, bool endRound = true)
+    private void SetWinType(Entity<NukeopsRuleComponent> ent, WinType type, bool endRound = false) // Sunrise-Edit
     {
         ent.Comp.WinType = type;
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.NukeOps;
 using Content.Server.Popups;
 using Content.Server.Roles;
 using Content.Server.RoundEnd;
+using Content.Server.Explosion.EntitySystems;
 using Content.Server.Shuttles.Events;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Components;
@@ -44,6 +45,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly UplinkSystem _uplinkSystem = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly ExplosionSystem _explosions = default!;
 
     private static readonly ProtoId<CurrencyPrototype> TelecrystalCurrencyPrototype = "Telecrystal";
     private static readonly ProtoId<TagPrototype> NukeOpsUplinkTagPrototype = "NukeOpsUplink";
@@ -151,7 +154,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                         }
 
                         nukeops.WinConditions.Add(WinCondition.NukeExplodedOnCorrectStation);
-                        SetWinType((uid, nukeops), WinType.OpsMajor);
+                        SetWinType((uid, nukeops), WinType.OpsMajor, false); // Sunrise-Edit
                         correctStation = true;
                     }
 
@@ -166,9 +169,10 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 nukeops.WinConditions.Add(WinCondition.NukeExplodedOnIncorrectLocation);
             }
 
-            if (GameTicker.IsGameRuleActive("Nukeops")) // If it's Nukeops then end the round on any detonation
+            // Sunrise edit start - replace instant end of round with calling/accelerating evac shuttle
+            if (GameTicker.IsGameRuleActive("Nukeops"))
             {
-                _roundEndSystem.EndRound();
+                _roundEndSystem.ForceSetCountdown(TimeSpan.FromSeconds(10), cantRecall: true);
             }
             else
             { // It's a LoneOp. Only end the round if the station was destroyed
@@ -177,7 +181,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 {
                     if (cond.ToString().ToLower() == "NukeExplodedOnCorrectStation") // If this is true, then the nuke destroyed the station! It's likely everyone is very dead so keeping the round going is pointless.
                     {
-                        _roundEndSystem.EndRound(); // end the round!
+                        _roundEndSystem.ForceSetCountdown(TimeSpan.FromSeconds(10), cantRecall: true);
                         handled = true;
                         break;
                     }
@@ -187,6 +191,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                     GameTicker.EndGameRule(uid);
                 }
             }
+            // Sunrise edit end
         }
     }
 
@@ -499,15 +504,22 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         if (nukeops.RoundEndBehavior == RoundEndBehavior.Nothing) // It's still worth checking if operatives have all died, even if the round-end behaviour is nothing.
             return; // Shouldn't actually try to end the round in the case of nothing though.
 
-        _roundEndSystem.DoRoundEndBehavior(nukeops.RoundEndBehavior,
-        nukeops.EvacShuttleTime,
-        nukeops.RoundEndTextSender,
-        nukeops.RoundEndTextShuttleCall,
-        nukeops.RoundEndTextAnnouncement);
+        // Sunrise edit start - when operatives die, explode their shuttle, delete their base map, and end the game rule.
+        if (shuttle != null)
+        {
+            _explosions.QueueExplosion(shuttle.Value, "Default", 500f, 3f, 30f);
+        }
 
+        if (TryComp<RuleGridsComponent>(ent, out var ruleGrids) && ruleGrids.Map != null)
+        {
+            _mapSystem.DeleteMap(ruleGrids.Map.Value);
+        }
+
+        GameTicker.EndGameRule(ent);
 
         // prevent it called multiple times
         nukeops.RoundEndBehavior = RoundEndBehavior.Nothing;
+        // Sunrise edit end
     }
 
     private void OnAfterAntagEntSelected(Entity<NukeopsRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared.Store;
 using Content.Shared.Tag;
 using Content.Shared.Zombies;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Linq;
@@ -47,6 +48,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     [Dependency] private readonly UplinkSystem _uplinkSystem = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly ExplosionSystem _explosions = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
     private static readonly ProtoId<CurrencyPrototype> TelecrystalCurrencyPrototype = "Telecrystal";
     private static readonly ProtoId<TagPrototype> NukeOpsUplinkTagPrototype = "NukeOpsUplink";
@@ -159,7 +161,12 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                     }
 
                     if (correctStation)
+                    {
+                        // Sunrise edit start - call/accelerate evac shuttle even on correct station explosion
+                        _roundEndSystem.ForceSetCountdown(TimeSpan.FromSeconds(10), cantRecall: true);
+                        // Sunrise edit end
                         continue;
+                    }
                 }
 
                 nukeops.WinConditions.Add(WinCondition.NukeExplodedOnIncorrectLocation);
@@ -179,7 +186,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 var handled = false;
                 foreach (var cond in nukeops.WinConditions)
                 {
-                    if (cond.ToString().ToLower() == "NukeExplodedOnCorrectStation") // If this is true, then the nuke destroyed the station! It's likely everyone is very dead so keeping the round going is pointless.
+                    if (cond == WinCondition.NukeExplodedOnCorrectStation) // If this is true, then the nuke destroyed the station! It's likely everyone is very dead so keeping the round going is pointless.
                     {
                         _roundEndSystem.ForceSetCountdown(TimeSpan.FromSeconds(10), cantRecall: true);
                         handled = true;
@@ -507,7 +514,16 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         // Sunrise edit start - when operatives die, explode their shuttle, delete their base map, and end the game rule.
         if (shuttle != null)
         {
-            _explosions.QueueExplosion(shuttle.Value, "Default", 500f, 3f, 30f);
+            if (TryComp<MapGridComponent>(shuttle.Value, out var grid))
+            {
+                var centerLocal = grid.LocalAABB.Center;
+                var epicenter = _transformSystem.ToMapCoordinates(new EntityCoordinates(shuttle.Value, centerLocal));
+                _explosions.QueueExplosion(epicenter, "DemolitionCharge", 30000f, 5f, 100f, cause: shuttle.Value);
+            }
+            else
+            {
+                _explosions.QueueExplosion(shuttle.Value, "DemolitionCharge", 30000f, 5f, 100f);
+            }
         }
 
         if (TryComp<RuleGridsComponent>(ent, out var ruleGrids) && ruleGrids.Map != null)

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -453,7 +453,22 @@ namespace Content.Server.RoundEnd
         {
             return ExpectedCountdownEnd != null;
         }
-        // Sunrise-end
+
+        // Sunrise-Start - force set the countdown and call the evac shuttle
+        public void ForceSetCountdown(TimeSpan countdownTime, bool cantRecall = true)
+        {
+            if (_gameTicker.RunLevel != GameRunLevel.InRound)
+                return;
+
+            if (_countdownTokenSource != null)
+            {
+                _countdownTokenSource.Cancel();
+                _countdownTokenSource = null;
+            }
+
+            RequestRoundEnd(countdownTime, null, false, cantRecall: cantRecall);
+        }
+        // Sunrise-End
     }
 
     public sealed class RoundEndSystemChangedEvent : EntityEventArgs

--- a/Content.Server/_Sunrise/AssaultOps/AssaultOpsRuleSystem.cs
+++ b/Content.Server/_Sunrise/AssaultOps/AssaultOpsRuleSystem.cs
@@ -1,11 +1,11 @@
 using Content.Server._Sunrise.AssaultOps.Icarus;
 using Content.Server.Antag;
-using Content.Server.Antag.Components;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Mind;
 using Content.Server.Revolutionary.Components;
-using Content.Server.RoundEnd;
+using Content.Server.Explosion.EntitySystems;
+using Robust.Shared.Map;
 using Content.Server.Station.Components;
 using Content.Server.Store.Systems;
 using Content.Server.Traitor.Uplink;
@@ -16,7 +16,6 @@ using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
-using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.NPC.Components;
@@ -33,13 +32,14 @@ namespace Content.Server._Sunrise.AssaultOps;
 public sealed class AssaultOpsRuleSystem : GameRuleSystem<AssaultOpsRuleComponent>
 {
     [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
-    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly SharedSubdermalImplantSystem _subdermalImplant = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly UplinkSystem _uplinkSystem = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly StoreSystem _store = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly ExplosionSystem _explosions = default!;
 
     [ValidatePrototypeId<TagPrototype>]
     private const string UplinkTagPrototype = "AssaultOpsUplink";
@@ -340,10 +340,21 @@ public sealed class AssaultOpsRuleSystem : GameRuleSystem<AssaultOpsRuleComponen
                 }
             }
 
-            if (operativesAlive)
-                continue;
+            assaultops.WinType = WinType.CrewMajor;
+            assaultops.WinConditions.Add(WinCondition.AllOpsDead);
 
-            _roundEndSystem.EndRound();
+            var shuttle = GetShuttle(uid);
+            if (shuttle != null)
+            {
+                _explosions.QueueExplosion(shuttle.Value, "Default", 500f, 3f, 30f);
+            }
+
+            if (TryComp<RuleGridsComponent>(uid, out var ruleGrids) && ruleGrids.Map != null)
+            {
+                _mapSystem.DeleteMap(ruleGrids.Map.Value);
+            }
+
+            GameTicker.EndGameRule(uid);
         }
     }
 
@@ -369,5 +380,16 @@ public sealed class AssaultOpsRuleSystem : GameRuleSystem<AssaultOpsRuleComponen
         {
             args.AddLine(Loc.GetString("assaultops-list-name", ("name", name), ("user", sessionData.UserName)));
         }
+    }
+
+    private EntityUid? GetShuttle(EntityUid ruleUid)
+    {
+        var query = EntityQueryEnumerator<AssaultOpsShuttleComponent>();
+        while (query.MoveNext(out var uid, out var shuttle))
+        {
+            if (shuttle.AssociatedRule == ruleUid)
+                return uid;
+        }
+        return null;
     }
 }

--- a/Content.Server/_Sunrise/AssaultOps/AssaultOpsRuleSystem.cs
+++ b/Content.Server/_Sunrise/AssaultOps/AssaultOpsRuleSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Mind;
 using Content.Server.Revolutionary.Components;
 using Content.Server.Explosion.EntitySystems;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Content.Server.Station.Components;
 using Content.Server.Store.Systems;
 using Content.Server.Traitor.Uplink;
@@ -40,6 +41,7 @@ public sealed class AssaultOpsRuleSystem : GameRuleSystem<AssaultOpsRuleComponen
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly ExplosionSystem _explosions = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
     [ValidatePrototypeId<TagPrototype>]
     private const string UplinkTagPrototype = "AssaultOpsUplink";
@@ -91,27 +93,11 @@ public sealed class AssaultOpsRuleSystem : GameRuleSystem<AssaultOpsRuleComponen
 
     protected override void Ended(EntityUid uid, AssaultOpsRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
     {
-        var assaultOperativesQuery = EntityQueryEnumerator<AssaultOperativeComponent>();
-        while (assaultOperativesQuery.MoveNext(out var operativeUid, out _))
-        {
-            QueueDel(operativeUid);
-        }
-
         var icarusKeysQuery = EntityQueryEnumerator<IcarusKeyComponent>();
         while (icarusKeysQuery.MoveNext(out var icarusKeyUid, out _))
         {
             QueueDel(icarusKeyUid);
         }
-
-        var assaultOpsShuttlequery = EntityQueryEnumerator<AssaultOpsShuttleComponent>();
-        while (assaultOpsShuttlequery.MoveNext(out var assaultOpsShuttleUid, out var shuttle))
-        {
-            if (shuttle.AssociatedRule == uid)
-            {
-                QueueDel(assaultOpsShuttleUid);
-            }
-        }
-        QueueDel(uid);
     }
 
     private void OnRuleLoadedGrids(Entity<AssaultOpsRuleComponent> ent, ref RuleLoadedGridsEvent args)
@@ -340,13 +326,25 @@ public sealed class AssaultOpsRuleSystem : GameRuleSystem<AssaultOpsRuleComponen
                 }
             }
 
+            if (operativesAlive)
+                continue;
+
             assaultops.WinType = WinType.CrewMajor;
             assaultops.WinConditions.Add(WinCondition.AllOpsDead);
 
             var shuttle = GetShuttle(uid);
             if (shuttle != null)
             {
-                _explosions.QueueExplosion(shuttle.Value, "Default", 500f, 3f, 30f);
+                if (TryComp<MapGridComponent>(shuttle.Value, out var grid))
+                {
+                    var centerLocal = grid.LocalAABB.Center;
+                    var epicenter = _transformSystem.ToMapCoordinates(new EntityCoordinates(shuttle.Value, centerLocal));
+                    _explosions.QueueExplosion(epicenter, "DemolitionCharge", 30000f, 5f, 100f, cause: shuttle.Value);
+                }
+                else
+                {
+                    _explosions.QueueExplosion(shuttle.Value, "DemolitionCharge", 30000f, 5f, 100f);
+                }
             }
 
             if (TryComp<RuleGridsComponent>(uid, out var ruleGrids) && ruleGrids.Map != null)

--- a/Content.Server/_Sunrise/AssaultOps/Icarus/IcarusBeamComponent.cs
+++ b/Content.Server/_Sunrise/AssaultOps/Icarus/IcarusBeamComponent.cs
@@ -7,25 +7,25 @@ public sealed partial class IcarusBeamComponent : Component
     ///     Beam moving speed.
     /// </summary>
     [DataField]
-    public float Speed = 8f;
+    public float Speed = 25f;
 
     /// <summary>
     ///     The beam will be automatically cleaned up after this time.
     /// </summary>
     [DataField]
-    public TimeSpan Lifetime = TimeSpan.FromSeconds(200);
+    public TimeSpan Lifetime = TimeSpan.FromSeconds(100);
 
     /// <summary>
     ///     With this set to true, beam will automatically set the tiles under them to space.
     /// </summary>
     [DataField]
-    public bool DestroyTiles = true;
+    public bool DestroyTiles = false;
 
     [DataField]
-    public float DestroyRadius = 4f;
+    public float DestroyRadius = 5f;
 
     [DataField]
-    public float FlameRadius = 8f;
+    public float FlameRadius = 16f;
 
     public TimeSpan LifetimeEnd;
 }

--- a/Content.Server/_Sunrise/AssaultOps/Icarus/IcarusBeamSystem.cs
+++ b/Content.Server/_Sunrise/AssaultOps/Icarus/IcarusBeamSystem.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Ghost;
@@ -25,18 +24,22 @@ public sealed class IcarusBeamSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        var query = EntityQuery<IcarusBeamComponent, TransformComponent>(true);
-        foreach (var (comp, xform) in query)
+        // Sunrise edit start - continuously set velocity to prevent slowdown from damping/friction
+        var query = EntityQueryEnumerator<IcarusBeamComponent, TransformComponent, PhysicsComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var xform, out var phys))
         {
-            DestroyEntities(comp, xform);
-            BurnEntities(comp.Owner, comp, xform);
+            _physics.SetLinearVelocity(uid, xform.WorldRotation.ToWorldVec() * comp.Speed, body: phys);
+
+            DestroyEntities(uid, comp, xform);
+            BurnEntities(uid, comp, xform);
 
             if (comp.DestroyTiles)
                 DestroyTiles(comp, xform);
 
             if (_timing.CurTime > comp.LifetimeEnd)
-                QueueDel(comp.Owner);
+                QueueDel(uid);
         }
+        // Sunrise edit end
     }
 
     public override void Initialize()
@@ -102,13 +105,13 @@ public sealed class IcarusBeamSystem : EntitySystem
     /// <summary>
     /// Handle deleting entities in beam radius.
     /// </summary>
-    private void DestroyEntities(IcarusBeamComponent component, TransformComponent trans)
+    private void DestroyEntities(EntityUid beam, IcarusBeamComponent component, TransformComponent trans)
     {
         var radius = component.DestroyRadius - 0.5f;
         var entitys = _lookup.GetEntitiesInRange(trans.MapID, trans.WorldPosition, radius);
         foreach (var entity in entitys)
         {
-            if (!CanDestroy(component, entity))
+            if (!CanDestroy(beam, component, entity))
                 continue;
 
             QueueDel(entity);
@@ -123,7 +126,7 @@ public sealed class IcarusBeamSystem : EntitySystem
         var radius = component.FlameRadius * 2;
         foreach (var entity in _lookup.GetEntitiesInRange(trans.MapID, trans.WorldPosition, radius))
         {
-            if (!CanDestroy(component, entity))
+            if (!CanDestroy(beam, component, entity))
                 continue;
 
             if (!TryComp<FlammableComponent>(entity, out var flammable))
@@ -135,10 +138,26 @@ public sealed class IcarusBeamSystem : EntitySystem
         }
     }
 
-    private bool CanDestroy(IcarusBeamComponent component, EntityUid entity)
+    private bool CanDestroy(EntityUid beam, IcarusBeamComponent component, EntityUid entity)
     {
-        return entity != component.Owner &&
-               !EntityManager.HasComponent<MapGridComponent>(entity) &&
-               !EntityManager.HasComponent<GhostComponent>(entity);
+        if (entity == beam)
+            return false;
+
+        if (EntityManager.HasComponent<MapGridComponent>(entity))
+            return false;
+
+        var current = entity;
+        while (current.IsValid())
+        {
+            if (EntityManager.HasComponent<GhostComponent>(current))
+                return false;
+
+            var xform = Transform(current);
+            if (xform.ParentUid == current)
+                break;
+            current = xform.ParentUid;
+        }
+
+        return true;
     }
 }

--- a/Content.Server/_Sunrise/AssaultOps/Icarus/IcarusTerminalSystem.cs
+++ b/Content.Server/_Sunrise/AssaultOps/Icarus/IcarusTerminalSystem.cs
@@ -234,7 +234,7 @@ public sealed class IcarusTerminalSystem : EntitySystem
                 _alertLevel.SetLevel(targetStation.Value, "delta", true, true, true);
             }
 
-            _roundEndSystem.DoRoundEndBehavior(RoundEndBehavior.ShuttleCall, TimeSpan.FromMinutes(1));
+            _roundEndSystem.ForceSetCountdown(TimeSpan.FromMinutes(1), cantRecall: true);
         });
     }
 

--- a/Content.Server/_Sunrise/BloodCult/GameRule/BloodCultRuleSystem.cs
+++ b/Content.Server/_Sunrise/BloodCult/GameRule/BloodCultRuleSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server._Sunrise.BloodCult.Objectives.Components;
 using Content.Server._Sunrise.BloodCult.Objectives.Systems;
 using Content.Server._Sunrise.BloodCult.Runes.Systems;
@@ -329,7 +329,7 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
         var query = EntityQueryEnumerator<BloodCultRuleComponent, GameRuleComponent>();
         var aliveCultistsCount = 0;
 
-        while (query.MoveNext(out _, out var cultRuleComponent, out _))
+        while (query.MoveNext(out var uid, out var cultRuleComponent, out _))
         {
             var cultisQuery = EntityQueryEnumerator<BloodCultistComponent>();
             while (cultisQuery.MoveNext(out var cultistUid, out _))
@@ -350,7 +350,7 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
                 continue;
 
             cultRuleComponent.WinCondition = CultWinCondition.CultFailure;
-            _roundEndSystem.EndRound();
+            GameTicker.EndGameRule(uid);
         }
     }
 
@@ -566,6 +566,8 @@ public sealed class BloodCultRuleSystem : GameRuleSystem<BloodCultRuleComponent>
             _gibbingSystem.Gib(mobState.Owner);
         }
 
-        _roundEndSystem.EndRound();
+        // Sunrise edit start - Nar'sie summon triggers evac shuttle instead of instant round end
+        _roundEndSystem.ForceSetCountdown(TimeSpan.FromSeconds(10), cantRecall: true);
+        // Sunrise edit end
     }
 }

--- a/Content.Server/_Sunrise/FleshCult/GameRule/FleshCultRuleSystem.cs
+++ b/Content.Server/_Sunrise/FleshCult/GameRule/FleshCultRuleSystem.cs
@@ -72,7 +72,6 @@ public sealed class FleshCultRuleSystem : GameRuleSystem<FleshCultRuleComponent>
         {
             RemComp<FleshCultistComponent>(cultist);
         }
-        QueueDel(uid);
     }
 
     private void OnObjectivesTextPrepend(EntityUid uid, FleshCultRuleComponent comp, ref ObjectivesTextPrependEvent args)

--- a/Content.Server/_Sunrise/FleshCult/GameRule/FleshCultRuleSystem.cs
+++ b/Content.Server/_Sunrise/FleshCult/GameRule/FleshCultRuleSystem.cs
@@ -111,7 +111,7 @@ public sealed class FleshCultRuleSystem : GameRuleSystem<FleshCultRuleComponent>
                 {
                     if (fleshCult.FleshHearts.ContainsKey(ev.FleshHeartUid))
                         fleshCult.FleshHearts[ev.FleshHeartUid] = FleshHeartStatus.Final;
-                    _roundEndSystem.EndRound();
+                    _roundEndSystem.ForceSetCountdown(TimeSpan.FromSeconds(10), cantRecall: true);
                     break;
                 }
             }

--- a/Resources/Prototypes/_Sunrise/AssaultOps/beam.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/beam.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: IcarusBeam
   name: icarus
   categories: [ HideSpawnMenu ]
@@ -6,13 +6,14 @@
   components:
   - type: Clickable
   - type: MovementIgnoreGravity
-  - type: GravityAffected
+  - type: TileFrictionModifier
+    modifier: 0
   - type: Sprite
     sprite: _Sunrise/AssaultOperatives/sunray.rsi
     drawdepth: Effects
     noRot: false
     netsync: false
-    scale: 6, 6
+    scale: 8, 8
     layers:
       - state: sunray_splash
       - state: sunray
@@ -30,9 +31,9 @@
     linearDamping: 0
     angularDamping: 0
   - type: PointLight
-    radius: 12
+    radius: 50
     color: yellow
-    energy: 10.0
+    energy: 25.0
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
<!--
[RU] Что вы предлагаете изменить с помощью своего PR?
[EN] What does this PR propose to change?
-->
Мажорные антагонисты больше не прерывают режим расказчика при поражении. В случае разгромной победы вместо резкого конца раунда прибывает эвак.

## Ссылка на багрепорт/Предложение | Related Issue/Bug Report
<!--
[RU] Ссылки на Дискуссии и Баг-репорты указывать здесь.
[EN] Provide links to Discussions or Bug Reports here.
-->

## Медиа (Видео/Скриншоты) | Media (Video/Screenshots)
<!--
[RU] Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
[EN] If your PR contains in-game changes, you must provide screenshots/video of the changes.
-->

<!--
## TODO

[RU] Не закончили? Добавьте список того, что требуется для завершения PR'а.
[EN] Not finished yet? Add a list of things that need to be done to complete this PR.

- [ ] Task 1
- [ ] Task 2
-->

**Changelog**

<!--
=== КАК ПИСАТЬ ЧЕЙНЖЛОГ / HOW TO WRITE A CHANGELOG ===

[RU]
1) Не считайте тип чейнжлога частью вашего предложения.
add: Новая фича = ПЛОХО | add: Добавлена новая фича = ХОРОШО
2) Подробно описывайте, что вы добавили и как это использовать. Все должно быть в меру.
fix: Исправлены мелочи = УЖАСНО | fix: Исправлена невозможность сцп173 двигаться = ХОРОШО
3) Не добавляйте технические детали. Чейнжлог пишется для игроков.
add: Добавлен новый хелпер-метод = ПЛОХО | НИЧЕГО НЕ ПИСАТЬ = ХОРОШО
* Иногда чейнжлог не нужен. Просто удалите это поле.

[EN]
1) Do not consider the changelog type as part of your sentence.
add: New feature = BAD | add: Added a new feature = GOOD
2) Describe in detail what you added and how to use it. Keep it balanced.
fix: Fixed minor things = TERRIBLE | fix: Fixed SCP-173 being unable to move = GOOD
3) Do not add technical details. The changelog is for players.
add: Added a new helper method = BAD | WRITING NOTHING = GOOD
* Sometimes a changelog is not needed. Just delete this field entirely.
-->

:cl: VigersRay
- tweak: В таких режимах как: ДО, ЯО, Культ крови и Культ плоти больше нету окончания раунда при смерти всех антагонистов.
- tweak: Теперь в случае смерти всех членов ДО или ЯО их шаттл совершит самоуничтожение.
- tweak: В случае призыва Нарси, взрыве ядерной боеголовки, активации сердца плоти или выстрела Икаруса вместо завершения раунда прибудет эвак для спасения выживших.
- remove: При смерти ЯО больше нету оповещения о их смерти и вызова эвакуационного шаттла.
- fix: Снаряд Икаруса вновь пробивает станцию насквозь.
- fix: При смерти ДО ключи Икаруса будут удалены во избежания дубликации на случай появления второго отряда.
- tweak: Снаряд Икаруса больше не уничтожает тайлы станции но имеет больший радиус поджога и уничтожения сущностей, а так же повышеную скорость.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен публичный метод для принудительного установки необратимого обратного отсчёта эвакуации.

* **Изменения игровых механик**
  * Режимы (ассалт, ньюкопс, культы и др.) при поражении станции или выполнении условий теперь запускают короткий необратимый обратный отсчёт вместо мгновенного завершения раунда.
  * В некоторых случаях завершение затрагивает только конкретное игровое правило: ставится эффект на шаттле, удаляется связанная карта и завершается правило, а не весь раунд.

* **Тесты**
  * Обновлены тесты: теперь проверяют завершение только игрового правила, а не всего раунда.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->