### PR TITLE
Добавление навигатора в AdminPDA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1173,6 +1173,7 @@
       - WantedListCartridge
       - MedTekCartridge
       - AstroNavCartridge
+      - NavigatorCartridge # Sunrise-Edit
   - type: Tag #  Ignore Chameleon tags
     tags:
     - DoorBumpOpener


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
Добавляется катридж навигатора от Sunrise в прототип AdminPDA

## Ссылка на багрепорт/Предложение | Related Issue/Bug Report
Задача #3951

**Changelog**

add: Добавлен катридж навигатора в КПК Администраторов

:cl: Coconut_Law
- add: Добавлен навигатор в КПК Администратора


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * В Admin PDA добавлен предустановленный картридж NavigatorCartridge, поэтому устройство сразу получает больше готовых возможностей навигации.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->