### PR TITLE
Фикс бага с гибом при позднем одновременном присоединении 2х игроков

### DIFF
--- a/Content.IntegrationTests/Tests/_Sunrise/Shuttles/SunriseArrivalsReservationTest.cs
+++ b/Content.IntegrationTests/Tests/_Sunrise/Shuttles/SunriseArrivalsReservationTest.cs
@@ -1,0 +1,490 @@
+#nullable enable
+using System.Collections.Generic;
+using Content.Server._Sunrise.Shuttles.Components;
+using Content.Server._Sunrise.Shuttles.Systems;
+using Content.Server.Shuttles;
+using Content.Server.Shuttles.Components;
+using Content.Server.Shuttles.Events;
+using Content.Shared.Shuttles.Components;
+using Content.Shared.Shuttles.Systems;
+using Content.Tests;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests._Sunrise.Shuttles;
+
+[TestFixture]
+public sealed class SunriseArrivalsReservationTest : ContentUnitTest
+{
+    private const string ArrivalDockTag = "DockArrivals";
+
+    [Test]
+    public async Task OverlappingAndTouchingAreasCannotBeReservedTogether()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var arrivalsSystem = entityManager.System<SunriseArrivalsSystem>();
+
+        var firstDispatched = false;
+        var overlappingDispatched = false;
+        var touchingDispatched = false;
+        var marginDispatched = false;
+
+        await server.WaitPost(() =>
+        {
+            var targetGrid = SpawnEntity(entityManager);
+            var first = CreateArrivalShuttle(entityManager);
+            var overlapping = CreateArrivalShuttle(entityManager);
+            var touching = CreateArrivalShuttle(entityManager);
+            var withinMargin = CreateArrivalShuttle(entityManager);
+
+            firstDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                first,
+                targetGrid,
+                new Box2(0f, 0f, 2f, 2f));
+            overlappingDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                overlapping,
+                targetGrid,
+                new Box2(1f, 0f, 3f, 2f));
+            touchingDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                touching,
+                targetGrid,
+                new Box2(2f, 0f, 4f, 2f));
+            marginDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                withinMargin,
+                targetGrid,
+                new Box2(2.005f, 0f, 4.005f, 2f));
+        });
+
+        await server.WaitAssertion(() => Assert.Multiple(() =>
+        {
+            Assert.That(firstDispatched, Is.True);
+            Assert.That(overlappingDispatched, Is.False);
+            Assert.That(touchingDispatched, Is.False);
+            Assert.That(marginDispatched, Is.False);
+        }));
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DistantAreasOnSameGridCanBeReservedTogether()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var arrivalsSystem = entityManager.System<SunriseArrivalsSystem>();
+
+        var firstDispatched = false;
+        var secondDispatched = false;
+
+        await server.WaitPost(() =>
+        {
+            var targetGrid = SpawnEntity(entityManager);
+            var first = CreateArrivalShuttle(entityManager);
+            var second = CreateArrivalShuttle(entityManager);
+
+            firstDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                first,
+                targetGrid,
+                new Box2(0f, 0f, 2f, 2f));
+            secondDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                second,
+                targetGrid,
+                new Box2(2.02f, 0f, 4.02f, 2f));
+        });
+
+        await server.WaitAssertion(() => Assert.Multiple(() =>
+        {
+            Assert.That(firstDispatched, Is.True);
+            Assert.That(secondDispatched, Is.True);
+        }));
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SameLocalAreaOnDifferentTargetGridsDoesNotConflict()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var arrivalsSystem = entityManager.System<SunriseArrivalsSystem>();
+
+        var firstDispatched = false;
+        var secondDispatched = false;
+
+        await server.WaitPost(() =>
+        {
+            var firstTargetGrid = SpawnEntity(entityManager);
+            var secondTargetGrid = SpawnEntity(entityManager);
+            var first = CreateArrivalShuttle(entityManager);
+            var second = CreateArrivalShuttle(entityManager);
+            var area = new Box2(0f, 0f, 2f, 2f);
+
+            firstDispatched = Dispatch(arrivalsSystem, entityManager, first, firstTargetGrid, area);
+            secondDispatched = Dispatch(arrivalsSystem, entityManager, second, secondTargetGrid, area);
+        });
+
+        await server.WaitAssertion(() => Assert.Multiple(() =>
+        {
+            Assert.That(firstDispatched, Is.True);
+            Assert.That(secondDispatched, Is.True);
+        }));
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DockedShuttleKeepsItsAreaReserved()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var arrivalsSystem = entityManager.System<SunriseArrivalsSystem>();
+
+        var firstDispatched = false;
+        var secondDispatched = false;
+        SunriseArrivalsShuttleComponent? firstArrivals = null;
+
+        await server.WaitPost(() =>
+        {
+            var targetGrid = SpawnEntity(entityManager);
+            var first = CreateArrivalShuttle(entityManager);
+            var second = CreateArrivalShuttle(entityManager);
+            var area = new Box2(0f, 0f, 2f, 2f);
+
+            firstDispatched = Dispatch(arrivalsSystem, entityManager, first, targetGrid, area);
+            first.Arrivals.State = SunriseArrivalsShuttleState.Docked;
+            firstArrivals = first.Arrivals;
+            secondDispatched = Dispatch(arrivalsSystem, entityManager, second, targetGrid, area);
+        });
+
+        await server.WaitAssertion(() => Assert.Multiple(() =>
+        {
+            Assert.That(firstDispatched, Is.True);
+            Assert.That(firstArrivals!.ReservedDockingArea, Is.Not.Null);
+            Assert.That(secondDispatched, Is.False);
+        }));
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DepartureRemovalAndFailedDockingReleaseReservation()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var arrivalsSystem = entityManager.System<SunriseArrivalsSystem>();
+
+        var targetGrid = EntityUid.Invalid;
+        var departurePort = EntityUid.Invalid;
+        var foreignDeparturePort = EntityUid.Invalid;
+        var foreignReservationOwner = EntityUid.Invalid;
+        var removalPort = EntityUid.Invalid;
+        var failedDockingPort = EntityUid.Invalid;
+        var departureArea = new Box2(0f, 0f, 2f, 2f);
+        var removalArea = new Box2(4f, 0f, 6f, 2f);
+        var failedDockingArea = new Box2(8f, 0f, 10f, 2f);
+        var departureDispatched = false;
+        var removalDispatched = false;
+        var failedDockingDispatched = false;
+        SunriseArrivalsShuttleComponent? failedArrivals = null;
+
+        await server.WaitPost(() =>
+        {
+            targetGrid = SpawnEntity(entityManager);
+            var departure = CreateArrivalShuttle(entityManager);
+            var removal = CreateArrivalShuttle(entityManager);
+            var failedDocking = CreateArrivalShuttle(entityManager);
+
+            departurePort = SpawnEntity(entityManager);
+            foreignDeparturePort = SpawnEntity(entityManager);
+            foreignReservationOwner = SpawnEntity(entityManager);
+            removalPort = SpawnEntity(entityManager);
+            failedDockingPort = SpawnEntity(entityManager);
+
+            departureDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                departure,
+                targetGrid,
+                departureArea,
+                departurePort,
+                foreignDeparturePort);
+            removalDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                removal,
+                targetGrid,
+                removalArea,
+                removalPort);
+            failedDockingDispatched = Dispatch(arrivalsSystem,
+                entityManager,
+                failedDocking,
+                targetGrid,
+                failedDockingArea,
+                failedDockingPort);
+
+            entityManager.GetComponent<FtlReservationComponent>(foreignDeparturePort).ReservedBy = foreignReservationOwner;
+            arrivalsSystem.StartDeparture(departure.Uid, departure.Arrivals);
+            entityManager.RemoveComponent<SunriseArrivalsShuttleComponent>(removal.Uid);
+
+            var completed = new FTLCompletedEvent(failedDocking.Uid, targetGrid);
+            entityManager.EventBus.RaiseLocalEvent(failedDocking.Uid, ref completed);
+            failedArrivals = failedDocking.Arrivals;
+        });
+
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() => Assert.Multiple(() =>
+        {
+            Assert.That(departureDispatched, Is.True);
+            Assert.That(removalDispatched, Is.True);
+            Assert.That(failedDockingDispatched, Is.True);
+            Assert.That(arrivalsSystem.IsArrivalAreaAvailable(EntityUid.Invalid, targetGrid, departureArea), Is.True);
+            Assert.That(arrivalsSystem.IsArrivalAreaAvailable(EntityUid.Invalid, targetGrid, removalArea), Is.True);
+            Assert.That(arrivalsSystem.IsArrivalAreaAvailable(EntityUid.Invalid, targetGrid, failedDockingArea), Is.True);
+            Assert.That(entityManager.HasComponent<FtlReservationComponent>(departurePort), Is.False);
+            Assert.That(entityManager.GetComponent<FtlReservationComponent>(foreignDeparturePort).ReservedBy,
+                Is.EqualTo(foreignReservationOwner));
+            Assert.That(entityManager.HasComponent<FtlReservationComponent>(removalPort), Is.False);
+            Assert.That(entityManager.HasComponent<FtlReservationComponent>(failedDockingPort), Is.False);
+            Assert.That(failedArrivals!.State, Is.EqualTo(SunriseArrivalsShuttleState.Queued));
+        }));
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task FailedDockingRestoresHoldingFtlAfterOldComponentRemoval()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var arrivalsSystem = entityManager.System<SunriseArrivalsSystem>();
+
+        var dispatched = false;
+        var restoredBeforeRemoval = false;
+        var queueContinued = false;
+        var restoredAfterRemoval = false;
+        FTLComponent? restoredFtl = null;
+        SunriseArrivalsShuttleComponent? failedArrivals = null;
+
+        await server.WaitPost(() =>
+        {
+            var targetGrid = SpawnEntity(entityManager);
+            var shuttleUid = map.Grid;
+            var arrivals = entityManager.EnsureComponent<SunriseArrivalsShuttleComponent>(shuttleUid);
+            var oldFtl = entityManager.EnsureComponent<FTLComponent>(shuttleUid);
+            var shuttle = entityManager.GetComponent<ShuttleComponent>(shuttleUid);
+            arrivals.State = SunriseArrivalsShuttleState.Queued;
+            oldFtl.State = FTLState.Travelling;
+
+            var failed = (Uid: shuttleUid, Arrivals: arrivals, Ftl: oldFtl);
+            var area = new Box2(0f, 0f, 2f, 2f);
+            dispatched = Dispatch(arrivalsSystem, entityManager, failed, targetGrid, area);
+
+            var completed = new FTLCompletedEvent(shuttleUid, targetGrid);
+            entityManager.EventBus.RaiseLocalEvent(shuttleUid, ref completed);
+            failedArrivals = arrivals;
+
+            restoredBeforeRemoval = arrivalsSystem.TryRestoreHoldingFtl(shuttleUid, arrivals, shuttle);
+
+            var next = CreateArrivalShuttle(entityManager);
+            queueContinued = Dispatch(arrivalsSystem, entityManager, next, targetGrid, area);
+
+            entityManager.RemoveComponent<FTLComponent>(shuttleUid);
+            restoredAfterRemoval = arrivalsSystem.TryRestoreHoldingFtl(shuttleUid, arrivals, shuttle);
+            entityManager.TryGetComponent(shuttleUid, out restoredFtl);
+        });
+
+        await server.WaitAssertion(() => Assert.Multiple(() =>
+        {
+            Assert.That(dispatched, Is.True);
+            Assert.That(failedArrivals!.State, Is.EqualTo(SunriseArrivalsShuttleState.Queued));
+            Assert.That(restoredBeforeRemoval, Is.False);
+            Assert.That(queueContinued, Is.True);
+            Assert.That(restoredAfterRemoval, Is.True);
+            Assert.That(restoredFtl, Is.Not.Null);
+            Assert.That(restoredFtl!.State, Is.EqualTo(FTLState.Starting));
+            Assert.That(restoredFtl.TravelTime, Is.EqualTo(3600f));
+        }));
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ConsecutiveDispatchesChooseOnlyNonConflictingRankedConfigurations()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var arrivalsSystem = entityManager.System<SunriseArrivalsSystem>();
+
+        var firstDispatched = false;
+        var secondDispatched = false;
+        SunriseArrivalsShuttleComponent? firstArrivals = null;
+        SunriseArrivalsShuttleComponent? secondArrivals = null;
+        FTLComponent? secondFtl = null;
+        EntityUid[] selectedPorts = [];
+
+        await server.WaitPost(() =>
+        {
+            var targetGrid = SpawnEntity(entityManager);
+            var first = CreateArrivalShuttle(entityManager);
+            var second = CreateArrivalShuttle(entityManager);
+            var occupiedArea = new Box2(0f, 0f, 2f, 2f);
+            var safeArea = new Box2(4f, 0f, 6f, 2f);
+
+            firstDispatched = Dispatch(arrivalsSystem, entityManager, first, targetGrid, occupiedArea);
+            firstArrivals = first.Arrivals;
+
+            var conflictingPriorityPort = SpawnPriorityDock(entityManager);
+            var nonPriorityPorts = SpawnDocks(entityManager, 3);
+            var onePriorityPort = SpawnPriorityDock(entityManager);
+            var farPriorityPorts = SpawnDocks(entityManager, 2);
+            entityManager.EnsureComponent<PriorityDockComponent>(farPriorityPorts[0]).Tag = ArrivalDockTag;
+            selectedPorts = SpawnDocks(entityManager, 2);
+            entityManager.EnsureComponent<PriorityDockComponent>(selectedPorts[0]).Tag = ArrivalDockTag;
+
+            var configs = new List<DockingConfig>
+            {
+                CreateDockingConfig(entityManager,
+                    targetGrid,
+                    occupiedArea,
+                    Angle.Zero,
+                    conflictingPriorityPort),
+                CreateDockingConfig(entityManager,
+                    targetGrid,
+                    safeArea,
+                    Angle.FromDegrees(1),
+                    nonPriorityPorts),
+                CreateDockingConfig(entityManager,
+                    targetGrid,
+                    safeArea,
+                    Angle.FromDegrees(1),
+                    onePriorityPort),
+                CreateDockingConfig(entityManager,
+                    targetGrid,
+                    safeArea,
+                    Angle.FromDegrees(30),
+                    farPriorityPorts),
+                CreateDockingConfig(entityManager,
+                    targetGrid,
+                    safeArea,
+                    Angle.FromDegrees(5),
+                    selectedPorts),
+            };
+
+            secondDispatched = arrivalsSystem.TryDispatchShuttleToSafeConfig(second.Uid,
+                second.Arrivals,
+                second.Ftl,
+                targetGrid,
+                configs);
+            secondArrivals = second.Arrivals;
+            secondFtl = second.Ftl;
+        });
+
+        await server.WaitAssertion(() => Assert.Multiple(() =>
+        {
+            Assert.That(firstDispatched, Is.True);
+            Assert.That(secondDispatched, Is.True);
+            Assert.That(firstArrivals!.ReservedDockingArea, Is.Not.Null);
+            Assert.That(secondArrivals!.ReservedDockingArea, Is.Not.Null);
+            Assert.That(firstArrivals.ReservedDockingArea!.Value.Enlarged(0.01f)
+                .Intersects(secondArrivals.ReservedDockingArea!.Value), Is.False);
+            Assert.That(secondFtl!.TargetAngle, Is.EqualTo(Angle.FromDegrees(5)));
+            Assert.That(secondArrivals.ReservedDocks, Is.EquivalentTo(selectedPorts));
+        }));
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static bool Dispatch(
+        SunriseArrivalsSystem arrivalsSystem,
+        IEntityManager entityManager,
+        (EntityUid Uid, SunriseArrivalsShuttleComponent Arrivals, FTLComponent Ftl) shuttle,
+        EntityUid targetGrid,
+        Box2 area,
+        params EntityUid[] targetDocks)
+    {
+        if (targetDocks.Length == 0)
+            targetDocks = [SpawnEntity(entityManager)];
+
+        var config = CreateDockingConfig(entityManager, targetGrid, area, Angle.Zero, targetDocks);
+        return arrivalsSystem.TryDispatchShuttleToSafeConfig(shuttle.Uid,
+            shuttle.Arrivals,
+            shuttle.Ftl,
+            targetGrid,
+            [config]);
+    }
+
+    private static (EntityUid Uid, SunriseArrivalsShuttleComponent Arrivals, FTLComponent Ftl)
+        CreateArrivalShuttle(IEntityManager entityManager)
+    {
+        var uid = SpawnEntity(entityManager);
+        var arrivals = entityManager.EnsureComponent<SunriseArrivalsShuttleComponent>(uid);
+        var ftl = entityManager.EnsureComponent<FTLComponent>(uid);
+        arrivals.State = SunriseArrivalsShuttleState.Queued;
+        ftl.State = FTLState.Travelling;
+        return (uid, arrivals, ftl);
+    }
+
+    private static DockingConfig CreateDockingConfig(
+        IEntityManager entityManager,
+        EntityUid targetGrid,
+        Box2 area,
+        Angle angle,
+        params EntityUid[] targetDocks)
+    {
+        var config = new DockingConfig
+        {
+            TargetGrid = targetGrid,
+            Area = area,
+            Coordinates = new EntityCoordinates(targetGrid, area.Center),
+            Angle = angle,
+        };
+
+        foreach (var targetDockUid in targetDocks)
+        {
+            var shuttleDockUid = SpawnEntity(entityManager);
+            var shuttleDock = entityManager.EnsureComponent<DockingComponent>(shuttleDockUid);
+            var targetDock = entityManager.EnsureComponent<DockingComponent>(targetDockUid);
+            config.Docks.Add((shuttleDockUid, targetDockUid, shuttleDock, targetDock));
+        }
+
+        return config;
+    }
+
+    private static EntityUid SpawnPriorityDock(IEntityManager entityManager)
+    {
+        var dock = SpawnEntity(entityManager);
+        entityManager.EnsureComponent<PriorityDockComponent>(dock).Tag = ArrivalDockTag;
+        return dock;
+    }
+
+    private static EntityUid[] SpawnDocks(IEntityManager entityManager, int count)
+    {
+        var docks = new EntityUid[count];
+        for (var i = 0; i < count; i++)
+        {
+            docks[i] = SpawnEntity(entityManager);
+        }
+
+        return docks;
+    }
+
+    private static EntityUid SpawnEntity(IEntityManager entityManager)
+    {
+        return entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+    }
+}

--- a/Content.Server/_Sunrise/Shuttles/Components/SunriseArrivalsShuttleComponent.cs
+++ b/Content.Server/_Sunrise/Shuttles/Components/SunriseArrivalsShuttleComponent.cs
@@ -85,6 +85,18 @@ public sealed partial class SunriseArrivalsShuttleComponent : Component
     /// Docks, зарезервированные этим шаттлом на целевой станции.
     /// </summary>
     public List<EntityUid> ReservedDocks = new();
+
+    /// <summary>
+    /// Целевой grid, на которой этим шаттлом зарезервирована область стыковки.
+    /// </summary>
+    [NonSerialized]
+    public EntityUid? ReservedTargetGrid;
+
+    /// <summary>
+    /// Область, которую шаттл займёт после стыковки, в локальных координатах целевой grid.
+    /// </summary>
+    [NonSerialized]
+    public Box2? ReservedDockingArea;
 }
 
 public enum SunriseArrivalsShuttleState : byte

--- a/Content.Server/_Sunrise/Shuttles/Systems/SunriseArrivalsSystem.cs
+++ b/Content.Server/_Sunrise/Shuttles/Systems/SunriseArrivalsSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Chat.Systems;
 using Content.Shared.Tag;
 using Content.Shared.Timing;
 using Content.Server.GameTicking;
+using Content.Server.Shuttles;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Shuttles.Systems;
@@ -48,10 +49,6 @@ public sealed class SunriseArrivalsSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly DockingSystem _docking = default!;
-
-    private bool _enabled;
-    private bool _arrivalsEnabled;
-    private string _shuttlePath = string.Empty;
 
     /// <summary>
     /// Время ожидания шаттла у дока станции перед принудительным отправлением.
@@ -114,9 +111,30 @@ public sealed class SunriseArrivalsSystem : EntitySystem
     /// </summary>
     private static readonly TimeSpan StationWarnInterval = TimeSpan.FromMinutes(1);
 
+    /// <summary>
+    /// Тег приоритетных docks прибытия.
+    /// </summary>
+    private const string ArrivalDockTag = "DockArrivals";
+
+    /// <summary>
+    /// Минимальный безопасный зазор между будущими корпусами шаттлов.
+    /// </summary>
+    private const float ArrivalReservationMargin = 0.01f;
+
+    private bool _enabled;
+    private bool _arrivalsEnabled;
+    private string _shuttlePath = string.Empty;
+    private EntityQuery<FTLComponent> _ftlQuery;
+    private EntityQuery<FtlReservationComponent> _ftlReservationQuery;
+    private EntityQuery<PriorityDockComponent> _priorityDockQuery;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _ftlQuery = GetEntityQuery<FTLComponent>();
+        _ftlReservationQuery = GetEntityQuery<FtlReservationComponent>();
+        _priorityDockQuery = GetEntityQuery<PriorityDockComponent>();
 
         SubscribeLocalEvent<PlayerSpawningEvent>(OnPlayerSpawning, after: new []{ typeof(ContainerSpawnPointSystem) }, before: new []{ typeof(SpawnPointSystem) });
         SubscribeLocalEvent<SunriseArrivalsShuttleComponent, FTLCompletedEvent>(OnFTLCompleted);
@@ -203,56 +221,47 @@ public sealed class SunriseArrivalsSystem : EntitySystem
         }
     }
 
-    private void OnFTLCompleted(EntityUid uid, SunriseArrivalsShuttleComponent component, ref FTLCompletedEvent args)
+    private void OnFTLCompleted(Entity<SunriseArrivalsShuttleComponent> ent, ref FTLCompletedEvent args)
     {
-        if (component.State != SunriseArrivalsShuttleState.Travelling)
+        if (ent.Comp.State != SunriseArrivalsShuttleState.Travelling)
             return;
 
-        if (IsDocked(uid))
+        if (IsDocked(ent))
         {
-            component.State = SunriseArrivalsShuttleState.Docked;
-            component.DockTime = _timing.CurTime;
-            component.Warned = false;
+            ent.Comp.State = SunriseArrivalsShuttleState.Docked;
+            ent.Comp.DockTime = _timing.CurTime;
+            ent.Comp.Warned = false;
 
-            if (component.Attendant != null)
+            if (ent.Comp.Attendant != null)
             {
                 var mapId = _transform.GetMapId(args.MapUid);
                 var station = _station.GetStationInMap(mapId);
                 var stationName = station != null ? Name(station.Value) : "Unknown";
                 var msg = Loc.GetString("sunrise-arrivals-attendant-arrival", ("station", stationName));
-                _chat.TrySendInGameICMessage(component.Attendant.Value, msg, InGameICChatType.Speak, hideChat: false);
+                _chat.TrySendInGameICMessage(ent.Comp.Attendant.Value, msg, InGameICChatType.Speak, hideChat: false);
             }
 
-            Log.Debug($"Arrivals shuttle {ToPrettyString(uid)} docked at station");
+            Log.Debug($"Arrivals shuttle {ToPrettyString(ent)} docked at station");
         }
         else
         {
             // Стыковка не удалась — возвращаем в очередь для повтора на следующем dispatch cycle
-            Log.Warning($"Arrivals shuttle {ToPrettyString(uid)} completed FTL but not docked, re-enqueueing");
-            component.State = SunriseArrivalsShuttleState.Queued;
-            EnqueueShuttle(uid);
-
-            // Возвращаем в бесконечный FTL
-            var shuttleComp = Comp<ShuttleComponent>(uid);
-            _shuttle.FTLToCoordinates(uid, shuttleComp,
-                Transform(uid).Coordinates, Angle.Zero, hyperspaceTime: 3600f);
+            Log.Warning($"Arrivals shuttle {ToPrettyString(ent)} completed FTL but not docked, re-enqueueing");
+            ClearArrivalReservation(ent, ent.Comp);
+            ent.Comp.State = SunriseArrivalsShuttleState.Queued;
+            EnqueueShuttle(ent);
         }
     }
 
-    private void OnShuttleShutdown(EntityUid uid, SunriseArrivalsShuttleComponent component, ComponentShutdown args)
+    private void OnShuttleShutdown(Entity<SunriseArrivalsShuttleComponent> ent, ref ComponentShutdown args)
     {
-        // Очищаем резервирования доков.
-        foreach (var dock in component.ReservedDocks)
-        {
-            RemCompDeferred<FtlReservationComponent>(dock);
-        }
-        component.ReservedDocks.Clear();
+        ClearArrivalReservation(ent, ent.Comp);
 
         // Удаляем из очереди, если там есть
         var poolQuery = EntityQueryEnumerator<SunriseArrivalsPoolComponent>();
         while (poolQuery.MoveNext(out _, out var pool))
         {
-            pool.Queue.Remove(uid);
+            pool.Queue.Remove(ent);
         }
     }
 
@@ -269,7 +278,8 @@ public sealed class SunriseArrivalsSystem : EntitySystem
 
         var curTime = _timing.CurTime;
 
-        TryDispatchFromQueue(curTime);
+        RestoreHoldingFtlForQueuedShuttles();
+        TryDispatchFromQueue();
 
         var query = EntityQueryEnumerator<SunriseArrivalsShuttleComponent>();
         while (query.MoveNext(out var uid, out var arrivals))
@@ -335,7 +345,7 @@ public sealed class SunriseArrivalsSystem : EntitySystem
     /// Пытается отправить шаттлы из очереди к свободным docks.
     /// Отправляет один шаттл на каждый свободный док за тик.
     /// </summary>
-    private void TryDispatchFromQueue(TimeSpan curTime)
+    private void TryDispatchFromQueue()
     {
         var poolQuery = EntityQueryEnumerator<SunriseArrivalsPoolComponent>();
         while (poolQuery.MoveNext(out _, out var pool))
@@ -362,7 +372,11 @@ public sealed class SunriseArrivalsSystem : EntitySystem
                     continue;
                 }
 
-                if (!TryDispatchShuttle(shuttleUid, arrivals))
+                // Cooldown предыдущего FTL не должен останавливать остальные шаттлы в очереди.
+                if (!_ftlQuery.TryComp(shuttleUid, out var ftl) || ftl.State != FTLState.Travelling)
+                    continue;
+
+                if (!TryDispatchShuttle(shuttleUid, arrivals, ftl))
                     break; // Свободных docks нет — прекращаем попытки
 
                 pool.Queue.RemoveAt(i);
@@ -372,40 +386,232 @@ public sealed class SunriseArrivalsSystem : EntitySystem
     }
 
     /// <summary>
+    /// Восстанавливает holding-FTL queued-шаттлов после удаления предыдущего FTL-компонента.
+    /// </summary>
+    private void RestoreHoldingFtlForQueuedShuttles()
+    {
+        var query = EntityQueryEnumerator<SunriseArrivalsShuttleComponent, ShuttleComponent>();
+        while (query.MoveNext(out var uid, out var arrivals, out var shuttle))
+        {
+            TryRestoreHoldingFtl(uid, arrivals, shuttle);
+        }
+    }
+
+    /// <summary>
+    /// Восстанавливает holding-FTL одного шаттла, если старый FTL-компонент уже удалён.
+    /// </summary>
+    internal bool TryRestoreHoldingFtl(
+        EntityUid uid,
+        SunriseArrivalsShuttleComponent arrivals,
+        ShuttleComponent shuttle)
+    {
+        if (_ftlQuery.HasComp(uid))
+            return false;
+
+        if (arrivals.State == SunriseArrivalsShuttleState.Travelling)
+        {
+            Log.Warning("Arrivals shuttle {Shuttle} (proto: {Prototype}) lost FTL while travelling; returning to queue",
+                ToPrettyString(uid),
+                Prototype(uid)?.ID ?? "unknown");
+            ClearArrivalReservation(uid, arrivals);
+            arrivals.State = SunriseArrivalsShuttleState.Queued;
+            EnqueueShuttle(uid);
+        }
+
+        if (arrivals.State != SunriseArrivalsShuttleState.Queued)
+            return false;
+
+        _shuttle.FTLToCoordinates(uid,
+            shuttle,
+            Transform(uid).Coordinates,
+            Angle.Zero,
+            hyperspaceTime: 3600f);
+
+        return _ftlQuery.HasComp(uid);
+    }
+
+    /// <summary>
     /// Пытается отправить шаттл из очереди к доку станции.
     /// Возвращает true, если шаттл отправлен, или false, если доступного дока нет.
     /// </summary>
-    private bool TryDispatchShuttle(EntityUid uid, SunriseArrivalsShuttleComponent arrivals)
+    private bool TryDispatchShuttle(EntityUid uid, SunriseArrivalsShuttleComponent arrivals, FTLComponent ftl)
     {
         var station = arrivals.Station;
         var targetGrid = _station.GetLargestGrid(station) ?? station;
+        var gridDocks = _docking.GetDocks(targetGrid);
+        var shuttleDocks = _docking.GetDocks(uid);
 
-        var config = _docking.GetDockingConfig(uid, targetGrid, "DockArrivals", false);
+        // Получаем все варианты: приоритетный тег применяется только после отсева конфликтующих областей.
+        var configs = _docking.GetDockingConfigs(uid,
+            targetGrid,
+            shuttleDocks,
+            gridDocks,
+            priorityTag: null,
+            ignored: false);
+
+        return TryDispatchShuttleToSafeConfig(uid, arrivals, ftl, targetGrid, configs);
+    }
+
+    /// <summary>
+    /// Выбирает безопасную конфигурацию, резервирует её и перенаправляет holding-FTL к станции.
+    /// </summary>
+    internal bool TryDispatchShuttleToSafeConfig(
+        EntityUid uid,
+        SunriseArrivalsShuttleComponent arrivals,
+        FTLComponent ftl,
+        EntityUid targetGrid,
+        List<DockingConfig> configs)
+    {
+        var config = SelectSafeDockingConfig(uid, targetGrid, configs, ArrivalDockTag);
         if (config == null)
             return false;
 
-        if (!TryComp<FTLComponent>(uid, out var ftl) || ftl.State != FTLState.Travelling)
-            return false;
+        ReserveArrivalConfiguration(uid, arrivals, targetGrid, config);
 
         // Перенаправляем существующий бесконечный FTL к доку.
         ftl.TargetCoordinates = config.Coordinates;
         ftl.TargetAngle = config.Angle;
-        ftl.PriorityTag = new ProtoId<TagPrototype>("DockArrivals");
+        ftl.PriorityTag = new ProtoId<TagPrototype>(ArrivalDockTag);
         ftl.TravelTime = DispatchFtlTime;
         ftl.StateTime = StartEndTime.FromCurTime(_timing, DispatchFtlTime);
-
-        // Резервируем docks
-        foreach (var docks in config.Docks)
-        {
-            var reservation = EnsureComp<FtlReservationComponent>(docks.DockBUid);
-            reservation.ReservedBy = uid;
-            arrivals.ReservedDocks.Add(docks.DockBUid);
-        }
 
         arrivals.State = SunriseArrivalsShuttleState.Travelling;
 
         Log.Debug($"Dispatched arrivals shuttle {ToPrettyString(uid)} to dock");
         return true;
+    }
+
+    /// <summary>
+    /// Выбирает лучшую конфигурацию, чья область не конфликтует с активными резервациями.
+    /// </summary>
+    internal DockingConfig? SelectSafeDockingConfig(
+        EntityUid shuttleUid,
+        EntityUid targetGrid,
+        List<DockingConfig> configs,
+        string? priorityTag)
+    {
+        DockingConfig? selected = null;
+        var selectedPriority = false;
+        var selectedDockCount = 0;
+        var selectedAngleDistance = double.PositiveInfinity;
+        var targetGridAngle = _transform.GetWorldRotation(targetGrid).Reduced();
+
+        foreach (var config in configs)
+        {
+            if (!IsArrivalAreaAvailable(shuttleUid, targetGrid, config.Area))
+                continue;
+
+            var isPriority = IsPriorityDockingConfig(config, priorityTag);
+            var dockCount = config.Docks.Count;
+            var angleDistance = Math.Abs(Angle.ShortestDistance(config.Angle.Reduced(), targetGridAngle).Theta);
+
+            if (selected != null)
+            {
+                if (isPriority != selectedPriority)
+                {
+                    if (!isPriority)
+                        continue;
+                }
+                else if (dockCount != selectedDockCount)
+                {
+                    if (dockCount < selectedDockCount)
+                        continue;
+                }
+                else if (angleDistance >= selectedAngleDistance)
+                {
+                    continue;
+                }
+            }
+
+            selected = config;
+            selectedPriority = isPriority;
+            selectedDockCount = dockCount;
+            selectedAngleDistance = angleDistance;
+        }
+
+        if (selected != null)
+            selected.TargetGrid = targetGrid;
+
+        return selected;
+    }
+
+    /// <summary>
+    /// Проверяет область конфигурации относительно уже отправленных и пристыкованных arrival-шаттлов.
+    /// </summary>
+    internal bool IsArrivalAreaAvailable(EntityUid shuttleUid, EntityUid targetGrid, Box2 area)
+    {
+        var bufferedArea = area.Enlarged(ArrivalReservationMargin);
+        var query = EntityQueryEnumerator<SunriseArrivalsShuttleComponent>();
+        while (query.MoveNext(out var otherUid, out var otherArrivals))
+        {
+            if (otherUid == shuttleUid ||
+                otherArrivals.ReservedTargetGrid != targetGrid ||
+                otherArrivals.ReservedDockingArea is not { } otherArea)
+            {
+                continue;
+            }
+
+            if (bufferedArea.Intersects(otherArea))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Сохраняет область конфигурации до резервирования её портов.
+    /// </summary>
+    internal void ReserveArrivalConfiguration(
+        EntityUid uid,
+        SunriseArrivalsShuttleComponent arrivals,
+        EntityUid targetGrid,
+        DockingConfig config)
+    {
+        DebugTools.Assert(arrivals.ReservedTargetGrid == null);
+        DebugTools.Assert(arrivals.ReservedDockingArea == null);
+        DebugTools.Assert(arrivals.ReservedDocks.Count == 0);
+
+        arrivals.ReservedTargetGrid = targetGrid;
+        arrivals.ReservedDockingArea = config.Area;
+
+        foreach (var docks in config.Docks)
+        {
+            var reservation = EnsureComp<FtlReservationComponent>(docks.DockBUid);
+            reservation.ReservedBy = uid;
+
+            if (!arrivals.ReservedDocks.Contains(docks.DockBUid))
+                arrivals.ReservedDocks.Add(docks.DockBUid);
+        }
+    }
+
+    /// <summary>
+    /// Снимает принадлежащие шаттлу резервации портов и его будущей области стыковки.
+    /// </summary>
+    internal void ClearArrivalReservation(EntityUid uid, SunriseArrivalsShuttleComponent arrivals)
+    {
+        foreach (var dock in arrivals.ReservedDocks)
+        {
+            if (_ftlReservationQuery.TryComp(dock, out var reservation) && reservation.ReservedBy == uid)
+                RemCompDeferred<FtlReservationComponent>(dock);
+        }
+
+        arrivals.ReservedDocks.Clear();
+        arrivals.ReservedTargetGrid = null;
+        arrivals.ReservedDockingArea = null;
+    }
+
+    private bool IsPriorityDockingConfig(DockingConfig config, string? priorityTag)
+    {
+        foreach (var docks in config.Docks)
+        {
+            if (_priorityDockQuery.TryComp(docks.DockBUid, out var priority) &&
+                priority.Tag?.Equals(priorityTag) == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -538,22 +744,16 @@ public sealed class SunriseArrivalsSystem : EntitySystem
 
     /// <summary>
     /// Запускает отправление шаттла от дока станции.
-    /// Сразу освобождает резервирования доков, чтобы шаттлы из очереди могли отправиться.
+    /// Сразу освобождает резервирования доков и области, чтобы очередь могла двигаться дальше.
     /// </summary>
-    private void StartDeparture(EntityUid uid, SunriseArrivalsShuttleComponent component)
+    internal void StartDeparture(EntityUid uid, SunriseArrivalsShuttleComponent component)
     {
         if (component.State == SunriseArrivalsShuttleState.Leaving)
             return;
 
         component.State = SunriseArrivalsShuttleState.Leaving;
         component.LeaveStartTime = null;
-
-        // Сразу очищаем резервирования доков, чтобы шаттлы из очереди могли отправиться на следующем тике.
-        foreach (var dock in component.ReservedDocks)
-        {
-            RemCompDeferred<FtlReservationComponent>(dock);
-        }
-        component.ReservedDocks.Clear();
+        ClearArrivalReservation(uid, component);
 
         // Удаляем существующий FTL-компонент, например cooldown прибытия, который
         // заблокировал бы TrySetupFTL. Без этого FTLToCoordinates тихо падает,
@@ -635,6 +835,8 @@ public sealed class SunriseArrivalsSystem : EntitySystem
     {
         if (TryComp<SunriseArrivalsShuttleComponent>(uid, out var arrivals))
         {
+            ClearArrivalReservation(uid, arrivals);
+
             // Безопасность: телепортируем игрока, если он все еще на шаттле
             if (arrivals.Player != null && IsPlayerOnShuttle(uid))
             {


### PR DESCRIPTION
:cl: SplikZerys
- fix: Пофикшен баг, когда людей гибало при позднем присоединении.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Улучшено резервирование зон стыковки шаттлов: перекрывающиеся области больше не выбираются одновременно.
  * Добавлена проверка совместимости целевых grid и ранжирование безопасных конфигураций при последовательной отправке шаттлов.
  * Резервы корректно сохраняются после стыковки и освобождаются при отправлении, удалении или неудачной стыковке.
  * Добавлено восстановление удерживающего FTL после сбоев или удаления прежнего компонента.

* **Тесты**
  * Добавлены интеграционные проверки сценариев резервирования, диспетчеризации и восстановления шаттлов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->