### PR TITLE
Ускорения отправки шаттлов ОБР: 300>180 секунд до вылета

### DIFF
--- a/Resources/Locale/en-US/_prototypes/entities/structures/shuttles/station_anchor.ftl
+++ b/Resources/Locale/en-US/_prototypes/entities/structures/shuttles/station_anchor.ftl
@@ -17,5 +17,5 @@ ent-ShuttleAnchor = { ent-ShuttleAnchorOff }
 ent-StationAnchorBaseDespawn = { "" }
     .desc = { "" }
 ent-StationAnchorDespawn = { ent-StationAnchorBaseDespawn }
-    .suffix = 5minDelete
+    .suffix = 3min
     .desc = { ent-StationAnchorBaseDespawn.desc }

--- a/Resources/Locale/ru-RU/_prototypes/entities/structures/shuttles/station_anchor.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/entities/structures/shuttles/station_anchor.ftl
@@ -17,5 +17,5 @@ ent-ShuttleAnchor = { ent-ShuttleAnchorOff }
 ent-StationAnchorBaseDespawn = { "" }
     .desc = { "" }
 ent-StationAnchorDespawn = { ent-StationAnchorBaseDespawn }
-    .suffix = 5 минут
+    .suffix = 3 минуты
     .desc = { ent-StationAnchorBaseDespawn.desc }

--- a/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
@@ -206,8 +206,8 @@
 - type: entity
   parent: StationAnchorBaseDespawn
   id: StationAnchorDespawn
-  suffix: 5minDelete
+  suffix: 3minDelete
   components:
   - type: TimedDespawn
-    lifetime: 300
+    lifetime: 180
 #Sunrise-End


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
<!--
Что вы предлагаете изменить с помощью своего PR?
-->

## Ссылка на багрепорт/Предложение
<!--
Ссылки на Дискуссии и Баг-репорты указывать здесь.
-->

## Медиа (Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR'а.

- [ ] Task 1
- [ ] Task 2
-->

<!--
## Требования к картам

Если ваше изменение требует изменение на картах - опишите требования тут.
Так мапперы серверов смогут понять, как адаптировать карты под ваши изменения.


-->

**Changelog**

<!--
=== КАК ПИСАТЬ ЧЕЙНЖЛОГ ===

[RU]
1) Не считайте тип чейнжлога частью вашего предложения.
add: Новая фича = ПЛОХО | add: Добавлена новая фича = ХОРОШО
2) Подробно описывайте, что вы добавили и как это использовать. Все должно быть в меру.
fix: Исправлены мелочи = УЖАСНО | fix: Исправлена невозможность игроков двигаться = ХОРОШО
3) Не добавляйте технические детали. Чейнжлог пишется для игроков.
add: Добавлен новый хелпер-метод = ПЛОХО | НИЧЕГО НЕ ПИСАТЬ = ХОРОШО
* Иногда чейнжлог не нужен. Просто удалите это поле.

-->

:cl: KaiserMaus
- tweak: NanoTrasen подтянули боевую подготовку ОБР, сокращено время до прилета отряда с момента вызова с 300 до 180 секунд.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения игрового процесса**
  - Время автоматического удаления станционного якоря сокращено с 5 до 3 минут.
  - Обновлён отображаемый таймер удаления: теперь он корректно показывает 3 минуты.
  - Изменение применяется для локализаций на русском и английском языках.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->