### PR TITLE
Фиксы рецептов

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshiftstunprod.yml
@@ -12,7 +12,7 @@
           steps:
             - material: MetalRod
               amount: 1
-            - tag: PowerCellSmall
+            - tag: PowerCell
               name: construction-graph-tag-power-cell-small
               icon:
                 sprite: Objects/Power/power_cells.rsi

--- a/Resources/Prototypes/_Starlight/Recipes/Crafting/Graphs/improvised/forged_omnitool.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Crafting/Graphs/improvised/forged_omnitool.yml
@@ -36,7 +36,7 @@
           sprite: Objects/Tools/welder_mini.rsi
           state: icon
         name: crafting-menu-name-EW
-      - tag: PowerCellSmall
+      - tag: PowerCell
         icon:
           sprite: Objects/Power/power_cells.rsi
           state: small

--- a/Resources/Prototypes/_Starlight/Recipes/Crafting/Graphs/improvised/improvised_multitool.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Crafting/Graphs/improvised/improvised_multitool.yml
@@ -15,7 +15,7 @@
       - material: Glass
         amount: 4
         doAfter: 10
-      - tag: PowerCellSmall
+      - tag: PowerCell
         icon:
           sprite: Objects/Power/power_cells.rsi
           state: small

--- a/Resources/Prototypes/_Sunrise/Recipes/Crafting/Graphs/misc/powercage.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Crafting/Graphs/misc/powercage.yml
@@ -9,13 +9,13 @@
             - material: Steel
               amount: 5
               doAfter: 0
-            - tag: PowerCellSmall
+            - tag: PowerCell
               name: step-trashgun-smallbattery
               icon:
                 sprite: Objects/Power/power_cells.rsi
                 state: small
               doAfter: 0
-            - tag: PowerCellSmall
+            - tag: PowerCell
               name: step-trashgun-smallbattery
               icon:
                 sprite: Objects/Power/power_cells.rsi

--- a/Resources/Prototypes/_Sunrise/Recipes/Crafting/Graphs/misc/trashgun.yml
+++ b/Resources/Prototypes/_Sunrise/Recipes/Crafting/Graphs/misc/trashgun.yml
@@ -18,7 +18,7 @@
             - material: Cable
               amount: 10
               doAfter: 0
-            - tag: PowerCellSmall
+            - tag: PowerCell
               name: step-trashgun-smallbattery
               icon:
                 sprite: Objects/Power/power_cells.rsi


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
Омнитулы, кованый и импровизированный, шок-палка и мусорная пушка мехов теперь создаются опять

## Ссылка на багрепорт/Предложение
<!--
Ссылки на Дискуссии и Баг-репорты указывать здесь.
-->

## Медиа (Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR'а.

- [ ] Task 1
- [ ] Task 2
-->

<!--
## Требования к картам

Если ваше изменение требует изменение на картах - опишите требования тут.
Так мапперы серверов смогут понять, как адаптировать карты под ваши изменения.


-->

**Changelog**



:cl: Kinar_7
- fix: Великие умы Грейтайда пересмотрели чертежи Омнитулов, шок-палки и мусорной пушки мехов, дабы последователи Грейтайда вновь могли их создавать. Слава Грейтайду!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Рецепты самодельного электрошокера, омнитула, мультитула, силовой клетки и мусорного оружия теперь принимают любые подходящие силовые элементы, а не только малые.
  * Остальные материалы и этапы сборки не изменились.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->