### PR TITLE
Исправление медиа чейнжлога PR #4704

### DIFF
--- a/Resources/Changelog/ChangelogSunrise.yml
+++ b/Resources/Changelog/ChangelogSunrise.yml
@@ -4873,3 +4873,7 @@
   id: 1995
   time: '2026-08-13T23:32:32.0000000+00:00'
   url: https://github.com/space-sunrise/sunrise-station/pull/4704
+  media:
+  - url: https://github.com/user-attachments/assets/8085d7d7-ea13-41cd-b2ec-260e66bba021
+    description: смешное видео
+    change: 0


### PR DESCRIPTION
## Что исправлено

Возвращено видео в запись чейнжлога PR #4704, которое было потеряно из-за одновременной работы старого SS14.Changelog и нового рабочего процесса.

Старый чейнжлог уже везде отключен

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Документация**
  * В запись журнала изменений добавлено видео с описанием «смешное видео».

<!-- end of auto-generated comment: release notes by coderabbit.ai -->