### PR TITLE
Фикс тестов

### DIFF
--- a/Content.IntegrationTests/Tests/Hands/HandTests.cs
+++ b/Content.IntegrationTests/Tests/Hands/HandTests.cs
@@ -78,7 +78,8 @@ public sealed class HandTests
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
             Connected = true,
-            DummyTicker = false
+            DummyTicker = false,
+            Dirty = true, // Sunrise added - у нас тесты в другом порядке запустились и упали потому что визден забыл тут Dirty
         });
         var server = pair.Server;
         var map = await pair.CreateTestMap();


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
<!--
Что вы предлагаете изменить с помощью своего PR?
-->

После применения нового json тесты стали в ~~неправильном~~ новом порядке, в который выяснилась визденовская проблема, где они забыли `Dirty = true` для очистки теста после себя.
А им норм, у них это не влияет из-за порядка тестов


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Тесты**
  * Обновлены настройки интеграционного теста для корректной проверки сохранения отключённого таймера в режиме `Dirty`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->